### PR TITLE
Fix syntax error with f-string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Output/
 
 # Python package dist
 dist/
+
+# Virtual env folder
+.venv/

--- a/testbed/cli/main.py
+++ b/testbed/cli/main.py
@@ -343,7 +343,7 @@ class SwarmitStatus:
                 self.status_data[deviceid_resp] = status
                 self.table.add_row(
                     deviceid_resp,
-                    f"{"[bold cyan]" if status == StatusType.Running else "[bold green]"}{status.name}",
+                    f'{"[bold cyan]" if status == StatusType.Running else "[bold green]"}{status.name}',
                 )
 
     def status(self, display=True):
@@ -391,7 +391,7 @@ def swarmit_flash(port, baudrate, firmware, yes, devices, ready_devices):
         console = Console()
         console.print(
             "[bold red]Error:[/] some acknowledgment are missing "
-            f"({", ".join(sorted(set(ready_devices).difference(set(ids))))}). "
+            f'({", ".join(sorted(set(ready_devices).difference(set(ids))))}). '
             "Aborting."
         )
         return False


### PR DESCRIPTION
Fixes the following error when running `swarmit` on Python 3.11.9:

```
$ swarmit --help
Traceback (most recent call last):
  File "/home/gfedrech/Developer/inria/openswarm/dev/swarmit/.venv/bin/swarmit", line 5, in <module>
    from testbed.cli.main import main
  File "/home/gfedrech/Developer/inria/openswarm/dev/swarmit/testbed/cli/main.py", line 346
    f"{"[bold cyan]" if status == StatusType.Running else "[bold green]"}{status.name}",
        ^
SyntaxError: f-string: expecting '}'
```