### PR TITLE
Fix crash of main dotbot application

### DIFF
--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -68,8 +68,8 @@ typedef struct __attribute__((packed)) {
     bool                    net_ack;            ///< Network core acked the latest request
     ipc_req_t               req;                ///< IPC network request
     uint8_t                 status;             ///< Experiment status
-    swrmt_device_type_t     device_type;        ///< Device type
     uint16_t                battery_level;      ///< Battery level in mV
+    swrmt_device_type_t     device_type;        ///< Device type
     ipc_log_data_t          log;                ///< Log data
     ipc_rng_data_t          rng;                ///< Rng shared data
     ipc_ota_data_t          ota;                ///< OTA data

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -33,20 +33,20 @@ void localization_init(void) {
 }
 
 void localization_process_data(void) {
-    puts("localization_process_data");
+    //puts("localization_process_data");
     db_lh2_process_location(&_localization_data.lh2);
 }
 
 void localization_get_position(position_2d_t *position) {
-    puts("Get position");
+    //puts("Get position");
     if (_localization_data.lh2.data_ready[0][0] == DB_LH2_PROCESSED_DATA_AVAILABLE && _localization_data.lh2.data_ready[1][0] == DB_LH2_PROCESSED_DATA_AVAILABLE) {
-        puts("Data available");
+        //puts("Data available");
 #if LH2_CALIBRATION_IS_VALID
         db_lh2_stop();
         db_lh2_calculate_position(_localization_data.lh2.locations[0][0].lfsr_location, _localization_data.lh2.locations[1][0].lfsr_location, 0, _localization_data.coordinates);
         position->x = (uint32_t)(_localization_data.coordinates[0] * 1e6);
         position->y = (uint32_t)(_localization_data.coordinates[1] * 1e6);
-        printf("Position (%u,%u)\n", position->x, position->y);
+        //printf("Position (%u,%u)\n", position->x, position->y);
         db_lh2_start();
 #endif
     }

--- a/device/bootloader/Source/localization.h
+++ b/device/bootloader/Source/localization.h
@@ -13,7 +13,7 @@
  * @}
  */
 
-#include "protocol.h"
+#include <stdint.h>
 
 /// DotBot protocol LH2 computed location
 typedef struct __attribute__((packed)) {

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -213,9 +213,23 @@ static void setup_ns_user(void) {
     NVIC_SetTargetState(GPIOTE0_IRQn);
     NVIC_SetTargetState(GPIOTE1_IRQn);
 
-    // All GPIOs are non secure
+    // Configure non-secure GPIOs
     NRF_SPU_S->GPIOPORT[0].PERM = 0;
     NRF_SPU_S->GPIOPORT[1].PERM = 0;
+
+    // Set LH2 pins as secure
+    NRF_SPU_S->GPIOPORT[DB_LH2_E_PORT].PERM |= (1 << DB_LH2_E_PIN);
+    NRF_SPU_S->GPIOPORT[DB_LH2_D_PORT].PERM |= (1 << DB_LH2_D_PIN);
+#if defined(BOARD_DOTBOT_V3)
+    NRF_SPU_S->GPIOPORT[1].PERM |= (1 << 7);
+#else
+    NRF_SPU_S->GPIOPORT[1].PERM |= (1 << 6);
+#endif
+
+    // Set AIN1 as secure, only for reading battery level on dotvot-v3
+#if defined(BOARD_DOTBOT_V3)
+    NRF_SPU_S->GPIOPORT[0].PERM |= (1 << 5); // AIN1 is P0.5
+#endif
 
     __DSB(); // Force memory writes before continuing
     __ISB(); // Flush and refill pipeline with updated permissions

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -75,8 +75,8 @@ typedef struct __attribute__((packed)) {
     bool                    net_ack;            ///< Network core acked the latest request
     ipc_req_t               req;                ///< IPC network request
     uint8_t                 status;             ///< Experiment status
-    swrmt_device_type_t     device_type;        ///< Device type
     uint16_t                battery_level;      ///< Battery level in mV
+    swrmt_device_type_t     device_type;        ///< Device type
     ipc_log_data_t          log;                ///< Log data
     ipc_rng_data_t          rng;                ///< Rng shared data
     ipc_ota_data_t          ota;                ///< OTA data


### PR DESCRIPTION
3 things were involved:
- battery level field must be 32bit aligned in shared memory struct
- stdio functions (puts, printf) cannot be used from code that is called via NSC regions
- make sure GPIOs used by lighthouse and battery level read remain secure