### PR TITLE
Support remote update of lighthouse calibration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,26 +71,23 @@ CI: matrix builds for 3 hardware targets × Debug/Release via Docker; multi-OS P
 - Commits in last 90 days: 5 (cadence dropped sharply)
 - Branches:
   - `add-blink-status-led` — 12 months stale, 370 ahead/1 behind. Likely abandoned.
-  - `config-net-id-via-flash` — 4 months stale, 24 ahead/19 behind. Possibly stalled in-flight; investigate before deleting.
+  - `config-net-id-via-flash` — its commits are already on `main`; the branch itself can be deleted.
 - TODO/FIXME/XXX/HACK: 6
 
 ## Hot spots and known gaps
 
 - **Two parallel bootloaders**: `device/bootloader/` and `device/bootloader-single-core/` plus per-board `.emProject` files at the repo root. Strong consolidation target if board variants converge.
 - **Tight coupling to `mari`**: submodule + Python package. `swarmit` and `mari` should likely be released/versioned together.
-- **`config-net-id-via-flash` branch** has 24 unmerged commits from January 2026 — that's where most recent work happened. Decide: rebase-and-merge, salvage individual commits, or close.
 - Heavy reliance on Mari being available (no fallback transport).
 
 ## Branch policy
 
 - Default: `main`
-- Investigate `config-net-id-via-flash` before any rebase work near it.
 - New work: feature branches off `main`, PRs even for solo work.
 
 ## Agent-task ideas
 
-- **Audit and resolve `config-net-id-via-flash`**: 24 ahead — rebase-and-merge or extract useful commits.
-- **Delete `add-blink-status-led`** (12 months stale, 370 commits diverged).
+- **Delete `add-blink-status-led`** (12 months stale, 370 commits diverged) and `config-net-id-via-flash` (already on `main`).
 - **Consolidate two bootloaders** if board variants allow.
 - **Add dashboard frontend tests** (vitest is set up via Vite but no tests authored).
 - **Document the Control Tower API** (FastAPI auto-generates schema; expose it as a stable contract).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ dotbot-calibration-exporter device/bootloader/Source
 
 Rebuild and reflash the bootloader for the new calibration to take effect.
 
+For **already-flashed** robots there's no need to rebuild — push the new
+calibration over the air with `swarmit calibrate-lh2`, see
+[Pushing an LH2 calibration over the air](#pushing-an-lh2-calibration-over-the-air)
+below.
+
 ### Gateway
 
 The communication between the computer and the swarm devices is performed via a
@@ -99,30 +104,49 @@ Print usage using `swarmit --help`:
 Usage: swarmit [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  -p, --port TEXT                 Serial port to use to send the bitstream to
-                                  the gateway. Default: /dev/ttyACM0.
-  -b, --baudrate INTEGER          Serial port baudrate. Default: 1000000.
-  -H, --mqtt-host TEXT            MQTT host. Default: localhost.
-  -P, --mqtt-port INTEGER         MQTT port. Default: 1883.
-  -T, --mqtt-use_tls              Use TLS with MQTT.
-  -n, --network-id INTEGER        Marilib network ID to use. Default: 1
-  -a, --adapter [edge|cloud]
-                                  Choose the adapter to communicate with the
-                                  gateway.  [default: edge]
-  -d, --devices TEXT              Subset list of devices to interact with,
-                                  separated with ,
-  -v, --verbose                   Enable verbose mode.
-  -V, --version                   Show the version and exit.
-  -h, --help                      Show this message and exit.
+  -c, --config-path FILE      Path to a .toml configuration file.
+  -p, --port TEXT             Serial port to use to send the bitstream to the
+                              gateway. Default: /dev/ttyACM0.
+  -b, --baudrate INTEGER      Serial port baudrate. Default: 1000000.
+  -H, --mqtt-host TEXT        MQTT host. Default: localhost.
+  -P, --mqtt-port INTEGER     MQTT port. Default: 1883.
+  -T, --mqtt-use_tls          Use TLS with MQTT.
+  -n, --network-id TEXT       Marilib network ID to use. Default: 0x1200
+  -a, --adapter [edge|cloud]  Choose the adapter to communicate with the
+                              gateway. Default: edge
+  -d, --devices TEXT          Subset list of device addresses to interact with,
+                              separated with ,
+  -v, --verbose               Enable verbose mode.
+  -V, --version               Show the version and exit.
+  -h, --help                  Show this message and exit.
 
 Commands:
-  flash    Flash a firmware to the robots.
-  message  Send a custom text message to the robots.
-  monitor  Monitor running applications.
-  reset    Reset robots locations.
-  start    Start the user application.
-  status   Print current status of the robots.
-  stop     Stop the user application.
+  calibrate-lh2  Send LH2 calibration data to the robots.
+  flash          Flash a firmware to the robots.
+  message        Send a custom text message to the robots.
+  monitor        Monitor running applications.
+  reset          Reset robots locations.
+  start          Start the user application.
+  status         Print current status of the robots.
+  stop           Stop the user application.
+```
+
+#### Pushing an LH2 calibration over the air
+
+Once a robot is flashed and connected to the Mari network, you can update its
+Lighthouse v2 homography without re-flashing the bootloader. The CLI pushes a
+calibration file produced by
+[`dotbot-lh2-calibration`](https://github.com/DotBots/dotbot-lh2-calibration)
+(default location `~/.dotbot/calibration.out`) over Mari; the network core
+writes it to the config page in flash and the SoC resets so the bootloader
+loads the new homographies on the next boot.
+
+```bash
+# Push the most recent calibration to every ready device on network 0xA000
+swarmit -n 0xA000 calibrate-lh2 ~/.dotbot/calibration.out
+
+# Or target a subset (-d takes a comma-separated list of device addresses)
+swarmit -n 0xA000 -d BC3D3C8A2A6F8E68 calibrate-lh2 ~/.dotbot/calibration.out
 ```
 
 ## Control Tower Dashboard

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -34,7 +34,7 @@ typedef enum {
     IPC_CHAN_RADIO_RX           = 1,    ///< Channel used for radio RX events
     IPC_CHAN_APPLICATION_START  = 2,    ///< Channel used for starting the application
     IPC_CHAN_APPLICATION_STOP   = 3,    ///< Channel used for stopping the application
-    IPC_CHAN_APPLICATION_RESET  = 4,    ///< Channel used for resetting the application
+    IPC_CHAN_SOC_RESET          = 4,    ///< Channel used to request a full SoC reset (e.g. after calibration commit)
     IPC_CHAN_LOG_EVENT          = 5,    ///< Channel used for logging events
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -38,6 +38,7 @@ typedef enum {
     IPC_CHAN_LOG_EVENT          = 5,    ///< Channel used for logging events
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
+    IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
 } ipc_channels_t;
 
 typedef struct __attribute__((packed)) {
@@ -53,6 +54,11 @@ typedef struct __attribute__((packed)) {
     int32_t  last_chunk_acked;
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t homography_count; // number of homography matrices used for localization
+    int32_t  homographies[LH2_BASESTATION_COUNT_MAX][3][3]; // homography matrices for localization
+} ipc_lh2_calibration_t;
 
 typedef struct {
     uint8_t value;  ///< Byte containing the random value read
@@ -77,6 +83,7 @@ typedef struct __attribute__((packed,aligned(8))) {
     position_2d_t           current_position;   ///< Current 2D position
     ipc_radio_pdu_t         tx_pdu;             ///< TX PDU
     ipc_radio_pdu_t         rx_pdu;             ///< RX PDU
+    ipc_lh2_calibration_t  lh2_calibration;     ///< LH2 calibration data
 } ipc_shared_data_t;
 
 void mutex_lock(void);

--- a/device/bootloader/Source/lh2_calibration.h
+++ b/device/bootloader/Source/lh2_calibration.h
@@ -4,10 +4,15 @@
 
 #include "localization.h"
 
-#define LH2_CALIBRATION_IS_VALID    (0)
-#define LH2_CALIBRATION_COUNT       (0)
+#define LH2_CALIBRATION_IS_VALID    (1)
+#define LH2_CALIBRATION_COUNT       (1)
 
-static int32_t swrmt_homography[LH2_CALIBRATION_COUNT][3][3] = {
+static int32_t swrmt_homographies[LH2_CALIBRATION_COUNT][3][3] = {
+    {
+        {-3041636, 14072108, -486318},
+        {-4101659, 1242328, 3168164},
+        {223, 5170, 1000},
+    },
 };
 
 #endif // __LH2_CALIBRATION_H

--- a/device/bootloader/Source/lh2_calibration.h
+++ b/device/bootloader/Source/lh2_calibration.h
@@ -4,15 +4,10 @@
 
 #include "localization.h"
 
-#define LH2_CALIBRATION_IS_VALID    (1)
-#define LH2_CALIBRATION_COUNT       (1)
+#define LH2_CALIBRATION_IS_VALID    (0)
+#define LH2_CALIBRATION_COUNT       (0)
 
-static int32_t swrmt_homographies[LH2_CALIBRATION_COUNT][3][3] = {
-    {
-        {-3041636, 14072108, -486318},
-        {-4101659, 1242328, 3168164},
-        {223, 5170, 1000},
-    },
+static int32_t swrmt_homography[LH2_CALIBRATION_COUNT][3][3] = {
 };
 
 #endif // __LH2_CALIBRATION_H

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -39,19 +39,6 @@ void localization_init(int32_t homographies[][3][3], uint32_t homography_count) 
         }
         db_lh2_store_homography(&_localization_data.lh2, lh_index, homographies[lh_index]);
     }
-
-    // now print as hex just for debugging
-    // FIXME: remove this part, only useful for debugging
-    printf("Homography matrices as hex:\n");
-    for (uint8_t lh_index = 0; lh_index < homography_count; lh_index++) {
-        printf("LH%u:\n", lh_index);
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 3; j++) {
-                printf("%02x ", homographies[lh_index][i][j]);
-            }
-            printf("\n");
-        }
-    }
 }
 
 bool localization_process_data(void) {

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -24,25 +24,34 @@ float _distance(position_2d_t *reference, position_2d_t *current) {
     return sqrtf(powf(dx, 2) + powf(dy, 2));
 }
 
-void localization_init(void) {
-    puts("Initialize localization");
+void localization_init(int32_t homographies[][3][3], uint32_t homography_count) {
+    printf("Initialize localization with %u homography matrices\n", homography_count);
     db_lh2_init(&_localization_data.lh2, &db_lh2_d, &db_lh2_e);
     db_lh2_start();
 
-#if LH2_CALIBRATION_IS_VALID
-    // Only store the homography if a valid one is set in lh2_calibration.h
-    for (uint8_t lh_index = 0; lh_index < LH2_CALIBRATION_COUNT; lh_index++) {
+    for (uint8_t lh_index = 0; lh_index < homography_count; lh_index++) {
         printf("Store homography matrix for LH%u:\n", lh_index);
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                printf("%i ", swrmt_homographies[lh_index][i][j]);
+                printf("%i ", homographies[lh_index][i][j]);
             }
             printf("\n");
         }
-        db_lh2_store_homography(&_localization_data.lh2, lh_index, swrmt_homographies[lh_index]);
+        db_lh2_store_homography(&_localization_data.lh2, lh_index, homographies[lh_index]);
     }
-#endif
 
+    // now print as hex just for debugging
+    // FIXME: remove this part, only useful for debugging
+    printf("Homography matrices as hex:\n");
+    for (uint8_t lh_index = 0; lh_index < homography_count; lh_index++) {
+        printf("LH%u:\n", lh_index);
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                printf("%02x ", homographies[lh_index][i][j]);
+            }
+            printf("\n");
+        }
+    }
 }
 
 bool localization_process_data(void) {

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -17,6 +17,7 @@ typedef struct {
 } localization_data_t;
 
 static __attribute__((aligned(4))) localization_data_t _localization_data = { 0 };
+static bool _calibration_loaded = false;
 
 float _distance(position_2d_t *reference, position_2d_t *current) {
     float dx = ((float)current->x - (float)reference->x);
@@ -39,6 +40,7 @@ void localization_init(int32_t homographies[][3][3], uint32_t homography_count) 
         }
         db_lh2_store_homography(&_localization_data.lh2, lh_index, homographies[lh_index]);
     }
+    _calibration_loaded = (homography_count > 0);
 }
 
 bool localization_process_data(void) {
@@ -52,7 +54,7 @@ bool localization_process_data(void) {
 }
 
 bool localization_get_position(position_2d_t *position) {
-    if (LH2_CALIBRATION_IS_VALID) {
+    if (_calibration_loaded) {
         db_lh2_stop();
         for (uint8_t lh_index = 0; lh_index < LH2_BASESTATION_COUNT; lh_index++) {
             if (_localization_data.lh2.data_ready[0][lh_index] == DB_LH2_PROCESSED_DATA_AVAILABLE && _localization_data.lh2.data_ready[1][lh_index] == DB_LH2_PROCESSED_DATA_AVAILABLE) {

--- a/device/bootloader/Source/localization.h
+++ b/device/bootloader/Source/localization.h
@@ -16,6 +16,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define LH2_BASESTATION_COUNT_MAX (16)
+
 /// DotBot protocol LH2 computed location
 typedef struct __attribute__((packed)) {
     uint32_t x;  ///< X coordinate in mm
@@ -27,7 +29,7 @@ typedef struct __attribute__((packed)) {
     int32_t homography_matrix[3][3];  ///< homography matrix, each element multiplied by 1e3
 } localization_homography_t;
 
-void localization_init(void);
+void localization_init(int32_t homographies[][3][3], uint32_t homography_count);
 
 bool localization_process_data(void);
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -295,6 +295,14 @@ int main(void) {
     // Start the network core
     release_network_core();
 
+    // Wait for the net core to finish its init (including _load_config()) before
+    // reading anything net-core-populated from ipc_shared_data. Otherwise the
+    // USER_IMAGE boot path below races _load_config and may read zeroed
+    // lh2_calibration / stale net_id.
+    while (!ipc_shared_data.net_ready) {
+        __WFE();
+    }
+
     mari_init();
 
     battery_level_init();

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -260,7 +260,7 @@ int main(void) {
                             1 << IPC_CHAN_OTA_START |
                             1 << IPC_CHAN_OTA_CHUNK |
                             1 << IPC_CHAN_APPLICATION_START |
-                            1 << IPC_CHAN_APPLICATION_RESET |
+                            1 << IPC_CHAN_SOC_RESET |
                             1 << IPC_CHAN_CALIBRATION_DATA
                         );
     NRF_IPC_S->SEND_CNF[IPC_CHAN_REQ]                   = 1 << IPC_CHAN_REQ;
@@ -268,7 +268,7 @@ int main(void) {
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_RADIO_RX]           = 1 << IPC_CHAN_RADIO_RX;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_START]  = 1 << IPC_CHAN_APPLICATION_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_STOP]   = 1 << IPC_CHAN_APPLICATION_STOP;
-    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_RESET]  = 1 << IPC_CHAN_APPLICATION_RESET;
+    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_SOC_RESET]          = 1 << IPC_CHAN_SOC_RESET;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_START]          = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_CHUNK]          = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_CALIBRATION_DATA]   = 1 << IPC_CHAN_CALIBRATION_DATA;
@@ -494,8 +494,8 @@ void IPC_IRQHandler(void) {
         _bootloader_vars.start_application = true;
     }
 
-    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_RESET]) {
-        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_RESET] = 0;
+    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_SOC_RESET]) {
+        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_SOC_RESET] = 0;
         _bootloader_vars.system_reset_requested = true;
     }
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -28,7 +28,8 @@
 #include "localization.h"
 #include "timer.h"
 
-#define SWARMIT_BASE_ADDRESS        (0x10000)
+#define SWARMIT_BASE_ADDRESS            (0x10000)
+#define SWARMIT_CONFIG_START_ADDRESS    (0x0103f800) // start of the last page (2KB) of the flash (0x01000000 + 0x00040000 - 0x800)
 
 #define BATTERY_UPDATE_DELAY        (1000U)
 #define POSITION_UPDATE_DELAY_MS    (100U) ///< 100ms delay between each position update
@@ -44,6 +45,7 @@ typedef struct {
     bool            ota_start_request;
     bool            ota_require_erase;
     bool            ota_chunk_request;
+    bool            lh2_calibration_ready;
     bool            start_application;
     position_2d_t   last_position;
     bool            position_update;
@@ -246,7 +248,8 @@ int main(void) {
                             1 << IPC_CHAN_RADIO_RX |
                             1 << IPC_CHAN_OTA_START |
                             1 << IPC_CHAN_OTA_CHUNK |
-                            1 << IPC_CHAN_APPLICATION_START
+                            1 << IPC_CHAN_APPLICATION_START |
+                            1 << IPC_CHAN_CALIBRATION_DATA
                             //1 << IPC_CHAN_APPLICATION_RESET
                         );
     NRF_IPC_S->SEND_CNF[IPC_CHAN_REQ]                   = 1 << IPC_CHAN_REQ;
@@ -257,6 +260,7 @@ int main(void) {
     //NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_RESET]  = 1 << IPC_CHAN_APPLICATION_RESET;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_START]          = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_CHUNK]          = 1 << IPC_CHAN_OTA_CHUNK;
+    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_CALIBRATION_DATA]   = 1 << IPC_CHAN_CALIBRATION_DATA;
     NVIC_EnableIRQ(IPC_IRQn);
     NVIC_ClearPendingIRQ(IPC_IRQn);
     NVIC_SetPriority(IPC_IRQn, IPC_IRQ_PRIORITY);
@@ -287,7 +291,6 @@ int main(void) {
 
     NVIC_ClearTargetState(SPIM4_IRQn);
     NVIC_ClearTargetState(IPC_IRQn);
-    localization_init();
 
     // Check reset reason and switch to user image if reset was not triggered by any wdt timeout
     uint32_t resetreas = NRF_RESET_S->RESETREAS;
@@ -337,6 +340,11 @@ int main(void) {
 
     while (1) {
         __WFE();
+
+        if (_bootloader_vars.lh2_calibration_ready) {
+            _bootloader_vars.lh2_calibration_ready = false;
+            localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+        }
 
         if (_bootloader_vars.ota_start_request) {
             _bootloader_vars.ota_start_request = false;
@@ -444,5 +452,10 @@ void IPC_IRQHandler(void) {
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_START]) {
         NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_START] = 0;
         _bootloader_vars.start_application = true;
+    }
+
+    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_CALIBRATION_DATA]) {
+        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_CALIBRATION_DATA] = 0;
+        _bootloader_vars.lh2_calibration_ready = true;
     }
 }

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -31,6 +31,14 @@
 #define SWARMIT_BASE_ADDRESS            (0x10000)
 #define SWARMIT_CONFIG_START_ADDRESS    (0x0103f800) // start of the last page (2KB) of the flash (0x01000000 + 0x00040000 - 0x800)
 
+// Boot-intent magic values. _boot_intent lives in secure RAM (.non_init in RAM1,
+// which the bootloader maps secure via tz_configure_ram_secure(0, 3)); user code
+// has no access. The bootloader reads it on every SREQ-triggered reset and routes
+// accordingly. Magic values keep an uninitialized first-power-on cycle from
+// accidentally matching either intent.
+#define SWRMT_BOOT_INTENT_USER_IMAGE    (0xC0DEC0DEu)
+#define SWRMT_BOOT_INTENT_BOOTLOADER    (0xB007B007u)
+
 #define BATTERY_UPDATE_DELAY        (1000U)
 #define POSITION_UPDATE_DELAY_MS    (100U) ///< 100ms delay between each position update
 
@@ -47,10 +55,13 @@ typedef struct {
     bool            ota_chunk_request;
     bool            lh2_calibration_ready;
     bool            start_application;
+    bool            system_reset_requested;
     position_2d_t   last_position;
     bool            position_update;
     bool            battery_update;
 } bootloader_app_data_t;
+
+static volatile uint32_t _boot_intent __attribute__((section(".non_init")));
 
 static const gpio_t _status_red_led = { .port = DB_RGB_LED_PWM_RED_PORT, .pin = DB_RGB_LED_PWM_RED_PIN };
 static const gpio_t _status_green_led = { .port = DB_RGB_LED_PWM_GREEN_PORT, .pin = DB_RGB_LED_PWM_GREEN_PIN };
@@ -249,15 +260,15 @@ int main(void) {
                             1 << IPC_CHAN_OTA_START |
                             1 << IPC_CHAN_OTA_CHUNK |
                             1 << IPC_CHAN_APPLICATION_START |
+                            1 << IPC_CHAN_APPLICATION_RESET |
                             1 << IPC_CHAN_CALIBRATION_DATA
-                            //1 << IPC_CHAN_APPLICATION_RESET
                         );
     NRF_IPC_S->SEND_CNF[IPC_CHAN_REQ]                   = 1 << IPC_CHAN_REQ;
     NRF_IPC_S->SEND_CNF[IPC_CHAN_LOG_EVENT]             = 1 << IPC_CHAN_LOG_EVENT;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_RADIO_RX]           = 1 << IPC_CHAN_RADIO_RX;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_START]  = 1 << IPC_CHAN_APPLICATION_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_STOP]   = 1 << IPC_CHAN_APPLICATION_STOP;
-    //NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_RESET]  = 1 << IPC_CHAN_APPLICATION_RESET;
+    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_APPLICATION_RESET]  = 1 << IPC_CHAN_APPLICATION_RESET;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_START]          = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_CHUNK]          = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_CALIBRATION_DATA]   = 1 << IPC_CHAN_CALIBRATION_DATA;
@@ -296,8 +307,16 @@ int main(void) {
     uint32_t resetreas = NRF_RESET_S->RESETREAS;
     NRF_RESET_S->RESETREAS = NRF_RESET_S->RESETREAS;
 
-     //Boot user image after soft system reset
-    if (resetreas & RESET_RESETREAS_SREQ_Detected << RESET_RESETREAS_SREQ_Pos) {
+    // Consume the boot intent set by whoever requested this reset (or random
+    // RAM on first power-on, which won't match either magic value).
+    uint32_t boot_intent = _boot_intent;
+    _boot_intent = 0;
+
+    // Boot user image after soft system reset, but only when the previous run
+    // explicitly asked for it. Calibration-commit resets fall through to
+    // bootloader-ready mode.
+    if ((resetreas & RESET_RESETREAS_SREQ_Detected << RESET_RESETREAS_SREQ_Pos)
+        && boot_intent == SWRMT_BOOT_INTENT_USER_IMAGE) {
         // Experiment is running
         ipc_shared_data.status = SWRMT_APPLICATION_RUNNING;
 
@@ -401,6 +420,12 @@ int main(void) {
         }
 
         if (_bootloader_vars.start_application) {
+            _boot_intent = SWRMT_BOOT_INTENT_USER_IMAGE;
+            NVIC_SystemReset();
+        }
+
+        if (_bootloader_vars.system_reset_requested) {
+            _boot_intent = SWRMT_BOOT_INTENT_BOOTLOADER;
             NVIC_SystemReset();
         }
 
@@ -459,6 +484,11 @@ void IPC_IRQHandler(void) {
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_START]) {
         NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_START] = 0;
         _bootloader_vars.start_application = true;
+    }
+
+    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_RESET]) {
+        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_RESET] = 0;
+        _bootloader_vars.system_reset_requested = true;
     }
 
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_CALIBRATION_DATA]) {

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -301,6 +301,13 @@ int main(void) {
         // Experiment is running
         ipc_shared_data.status = SWRMT_APPLICATION_RUNNING;
 
+        // ensure LH2 localization is initialized
+        if (ipc_shared_data.lh2_calibration.homography_count > 0 && ipc_shared_data.lh2_calibration.homography_count <= LH2_BASESTATION_COUNT_MAX) {
+            localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+        } else {
+            printf("Initializing without LH2 calibration data, homography count: %u\n", ipc_shared_data.lh2_calibration.homography_count);
+        }
+
         // Initialize watchdog and non secure access
         setup_ns_user();
         setup_watchdog0();

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -22,6 +22,8 @@
 
 #define IPC_LOG_SIZE     (128)
 
+#define LH2_BASESTATION_COUNT_MAX (16)
+
 typedef enum {
     IPC_REQ_NONE,        ///< Sorry, but nothing
     IPC_MARI_INIT_REQ,
@@ -39,6 +41,7 @@ typedef enum {
     IPC_CHAN_LOG_EVENT          = 5,    ///< Channel used for logging events
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
+    IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
 } ipc_channels_t;
 
 typedef struct {
@@ -64,6 +67,12 @@ typedef struct __attribute__((packed)) {
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 
+/// LH2 calibration data
+typedef struct __attribute__((packed)) {
+    uint32_t homography_count; // number of homography matrices used for localization
+    int32_t  homographies[LH2_BASESTATION_COUNT_MAX][3][3]; // homography matrices for localization
+} ipc_lh2_calibration_t;
+
 /// DotBot protocol LH2 computed location
 typedef struct __attribute__((packed)) {
     uint32_t x;  ///< X coordinate in mm
@@ -84,6 +93,7 @@ typedef struct __attribute__((packed)) {
     position_2d_t           current_position;   ///< Current 2D position
     ipc_radio_pdu_t         tx_pdu;             ///< TX pdu
     ipc_radio_pdu_t         rx_pdu;             ///< RX pdu
+    ipc_lh2_calibration_t    lh2_calibration;     ///< LH2 calibration data
 } ipc_shared_data_t;
 
 /**

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -37,7 +37,7 @@ typedef enum {
     IPC_CHAN_RADIO_RX           = 1,    ///< Channel used for radio RX events
     IPC_CHAN_APPLICATION_START  = 2,    ///< Channel used for starting the application
     IPC_CHAN_APPLICATION_STOP   = 3,    ///< Channel used for stopping the application
-    IPC_CHAN_APPLICATION_RESET  = 4,    ///< Channel used for resetting the application
+    IPC_CHAN_SOC_RESET          = 4,    ///< Channel used to request a full SoC reset (e.g. after calibration commit)
     IPC_CHAN_LOG_EVENT          = 5,    ///< Channel used for logging events
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -14,6 +14,7 @@
 #include <nrf.h>
 // Include BSP headers
 #include "ipc.h"
+#include "nvmc.h"
 #include "protocol.h"
 #include "rng.h"
 #include "sha256.h"
@@ -28,12 +29,20 @@
 #define NETCORE_MAIN_TIMER                  (0)
 
 #define SWARMIT_NET_CONFIG_START_ADDRESS    (0x0103f800) // start of the last page (2KB) of the flash (0x01000000 + 0x00040000 - 0x800)
-#define SWARMIT_CONFIG_MAGIC_VALUE          (0x5753524D) // "SWRM"
+#define SWARMIT_NET_CONFIG_PAGE             (127)       // page index for config (last page)
 // Important: select a Network ID according to the specific deployment you are making,
 // see the registry at https://crystalfree.atlassian.net/wiki/spaces/Mari/pages/3324903426/Registry+of+Mari+Network+IDs
 #define SWARMIT_DEFAULT_NET_ID              (0x12AA)
+#define LH2_BASESTATION_COUNT_MAX           (16)
 
 //=========================== variables =========================================
+
+typedef struct {
+    uint32_t has_net_id;                                    ///< true if network ID is set
+    uint32_t net_id;                                        ///< Mari network ID
+    uint32_t homography_count;                              ///< number of homography matrices used for localization
+    int32_t  homographies[LH2_BASESTATION_COUNT_MAX][3][3]; ///< homography matrices for localization
+} swarmit_config_t;
 
 typedef struct {
     bool        req_received;
@@ -53,12 +62,9 @@ typedef struct {
     uint32_t    metrics_rx_counter;
     uint32_t    metrics_tx_counter;
     bool        metrics_received;
+    swarmit_config_t config;
+    bool        lh2_calibration_ready;
 } swrmt_app_data_t;
-
-typedef struct {
-    uint32_t magic;      // to detect if config is valid
-    uint32_t net_id;     // Mari network ID
-} swarmit_config_t;
 
 static swrmt_app_data_t _app_vars = { 0 };
 extern schedule_t schedule_minuscule, schedule_tiny, schedule_small, schedule_huge, schedule_only_beacons, schedule_only_beacons_optimized_scan;
@@ -71,13 +77,14 @@ static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length
     memcpy(_app_vars.req_buffer, packet, length);
     uint8_t *ptr = _app_vars.req_buffer;
     uint8_t packet_type = (uint8_t)*ptr++;
-    if ((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) {
-        _app_vars.req_received = true;
-        return;
-    }
 
     if (length == sizeof(mr_metrics_payload_t) && packet_type == MARI_PAYLOAD_TYPE_METRICS_PROBE) {
         _app_vars.metrics_received = true;
+        return;
+    }
+
+    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_CALIBRATION_DATA)) {
+        _app_vars.req_received = true;
         return;
     }
 
@@ -122,14 +129,32 @@ static void mari_event_callback(mr_event_t event, mr_event_data_t event_data) {
     }
 }
 
-static uint16_t _net_id(void) {
-    const swarmit_config_t *cfg = (const swarmit_config_t *)SWARMIT_NET_CONFIG_START_ADDRESS;
+static void _load_config(void) {
+    // load config into RAM
+    const swarmit_config_t *cfg_flash = (const swarmit_config_t *)SWARMIT_NET_CONFIG_START_ADDRESS;
+    memcpy(&_app_vars.config, cfg_flash, sizeof(_app_vars.config));
 
-    if (cfg->magic != SWARMIT_CONFIG_MAGIC_VALUE) {
-        // No network config found, use default network ID
-        return SWARMIT_DEFAULT_NET_ID;
+    // set network ID
+    if (cfg_flash->has_net_id == 1) {
+        _app_vars.mari_net_id = (uint16_t)(_app_vars.config.net_id & 0xFFFFu);
+    } else {
+        _app_vars.mari_net_id = SWARMIT_DEFAULT_NET_ID;
     }
-    return (uint16_t)(cfg->net_id & 0xFFFFu);
+
+    // set lighthouse calibration data
+    if (_app_vars.config.homography_count > 0 && _app_vars.config.homography_count <= LH2_BASESTATION_COUNT_MAX) {
+        // copy homography matrices to shared memory without casting away volatile
+        for (uint32_t idx = 0; idx < _app_vars.config.homography_count; idx++) {
+            for (uint32_t row = 0; row < 3; row++) {
+                for (uint32_t col = 0; col < 3; col++) {
+                    ipc_shared_data.lh2_calibration.homographies[idx][row][col] =
+                        _app_vars.config.homographies[idx][row][col];
+                }
+            }
+        }
+        ipc_shared_data.lh2_calibration.homography_count = _app_vars.config.homography_count;
+        _app_vars.lh2_calibration_ready = true;
+    }
 }
 
 uint64_t _deviceid(void) {
@@ -145,7 +170,7 @@ static void _send_status(void) {
 int main(void) {
 
     _app_vars.device_id = _deviceid();
-    _app_vars.mari_net_id = _net_id();
+    _load_config();
 
     NRF_IPC_NS->INTENSET                             = (1 << IPC_CHAN_REQ) | (1 << IPC_CHAN_LOG_EVENT);
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_RADIO_RX]          = 1 << IPC_CHAN_RADIO_RX;
@@ -154,6 +179,7 @@ int main(void) {
     //NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_RESET] = 1 << IPC_CHAN_APPLICATION_RESET;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_START]         = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_CHUNK]         = 1 << IPC_CHAN_OTA_CHUNK;
+    NRF_IPC_NS->SEND_CNF[IPC_CHAN_CALIBRATION_DATA]  = 1 << IPC_CHAN_CALIBRATION_DATA;
     NRF_IPC_NS->RECEIVE_CNF[IPC_CHAN_REQ]            = 1 << IPC_CHAN_REQ;
     NRF_IPC_NS->RECEIVE_CNF[IPC_CHAN_LOG_EVENT]      = 1 << IPC_CHAN_LOG_EVENT;
 
@@ -170,6 +196,11 @@ int main(void) {
 
     while (1) {
         __WFE();
+
+        if (_app_vars.lh2_calibration_ready) {
+            _app_vars.lh2_calibration_ready = false;
+            NRF_IPC_NS->TASKS_SEND[IPC_CHAN_CALIBRATION_DATA] = 1;
+        }
 
         if (_app_vars.send_status) {
             _app_vars.send_status = false;
@@ -269,6 +300,52 @@ int main(void) {
                     }
                     printf("Process OTA chunk request (index: %u, size: %u)\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_size);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_CHUNK] = 1;
+                } break;
+                case SWRMT_MSG_CALIBRATION_DATA:
+                {
+                    if (ipc_shared_data.status != SWRMT_APPLICATION_READY) {
+                        break;
+                    }
+
+                    const swrmt_lh2_calibration_data_t *pkt = (const swrmt_lh2_calibration_data_t *)req->data;
+                    if (pkt->homography_index >= LH2_BASESTATION_COUNT_MAX) {
+                        printf("Invalid calibration index %u\n", pkt->homography_index);
+                        break;
+                    }
+
+                    /* Backup full config from flash (preserve has_net_id, net_id, etc.) */
+                    swarmit_config_t config;
+                    const swarmit_config_t *cfg_flash = (const swarmit_config_t *)SWARMIT_NET_CONFIG_START_ADDRESS;
+                    memcpy(&config, cfg_flash, sizeof(config));
+
+                    /* Merge new calibration into backup */
+                    config.homography_count = pkt->homography_count;
+                    memcpy(config.homographies[pkt->homography_index], pkt->homography, sizeof(config.homographies[0]));
+
+                    /* Erase config page then write entire config */
+                    nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
+                    nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &config, sizeof(config));
+
+                    /* Update IPC and notify bootloader immediately (no reboot needed) */
+                    // FIXME: remove this part, only useful for debugging
+                    mutex_lock();
+                    ipc_shared_data.lh2_calibration.homography_count = config.homography_count;
+                    for (uint32_t idx = 0; idx < config.homography_count; idx++) {
+                        for (uint32_t row = 0; row < 3; row++) {
+                            for (uint32_t col = 0; col < 3; col++) {
+                                ipc_shared_data.lh2_calibration.homographies[idx][row][col] =
+                                    config.homographies[idx][row][col];
+                            }
+                        }
+                    }
+                    mutex_unlock();
+                    _app_vars.lh2_calibration_ready = true;
+
+                    printf(
+                        "Calibration data stored (count: %u, index: %u)\n",
+                        pkt->homography_count,
+                        pkt->homography_index
+                    );
                 } break;
                 default:
                     break;

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -354,7 +354,13 @@ int main(void) {
                         break;
                     }
 
-                    /* Keep receiving matrices in RAM and commit once on the last index. */
+                    /* Keep receiving matrices in RAM and commit once on the last index.
+                       On the first packet of a new calibration session, zero the
+                       array so any unrecovered slot from the previous session
+                       does not silently survive into the flash commit. */
+                    if (pkt->homography_index == 0) {
+                        memset(_app_vars.config.homographies, 0, sizeof(_app_vars.config.homographies));
+                    }
                     _app_vars.config.homography_count = pkt->homography_count;
                     memcpy(_app_vars.config.homographies[pkt->homography_index], pkt->homography, sizeof(_app_vars.config.homographies[0]));
 

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -165,6 +165,13 @@ static void _send_status(void) {
     _app_vars.send_status = true;
 }
 
+static void _commit_config_and_reboot(void) {
+    nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
+    nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &_app_vars.config, sizeof(_app_vars.config));
+
+    puts("Calibration/config committed to flash");
+}
+
 //=========================== main ==============================================
 
 int main(void) {
@@ -312,27 +319,31 @@ int main(void) {
                         printf("Invalid calibration index %u\n", pkt->homography_index);
                         break;
                     }
+                    if (pkt->homography_count == 0 || pkt->homography_count > LH2_BASESTATION_COUNT_MAX) {
+                        printf("Invalid calibration count %u\n", pkt->homography_count);
+                        break;
+                    }
+                    if (pkt->homography_index >= pkt->homography_count) {
+                        printf("Invalid calibration tuple (idx=%u, count=%u)\n",
+                               pkt->homography_index,
+                               pkt->homography_count);
+                        break;
+                    }
 
-                    /* Backup full config from flash (preserve has_net_id, net_id, etc.) */
-                    swarmit_config_t config;
-                    const swarmit_config_t *cfg_flash = (const swarmit_config_t *)SWARMIT_NET_CONFIG_START_ADDRESS;
-                    memcpy(&config, cfg_flash, sizeof(config));
-
-                    /* Merge new calibration into backup */
-                    config.homography_count = pkt->homography_count;
-                    memcpy(config.homographies[pkt->homography_index], pkt->homography, sizeof(config.homographies[0]));
-
-                    /* Erase config page then write entire config */
-                    nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
-                    nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &config, sizeof(config));
-
-                    _app_vars.lh2_calibration_ready = true;
+                    /* Keep receiving matrices in RAM and commit once on the last index. */
+                    _app_vars.config.homography_count = pkt->homography_count;
+                    memcpy(_app_vars.config.homographies[pkt->homography_index], pkt->homography, sizeof(_app_vars.config.homographies[0]));
 
                     printf(
-                        "Calibration data stored (count: %u, index: %u)\n",
+                        "Calibration matrix received (count: %u, index: %u)\n",
                         pkt->homography_count,
                         pkt->homography_index
                     );
+
+                    /* User-defined protocol: last matrix index triggers flash commit + reboot. */
+                    if (pkt->homography_index == (pkt->homography_count - 1)) {
+                        _commit_config_and_reboot();
+                    }
                 } break;
                 default:
                     break;

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -326,19 +326,6 @@ int main(void) {
                     nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
                     nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &config, sizeof(config));
 
-                    /* Update IPC and notify bootloader immediately (no reboot needed) */
-                    // FIXME: remove this part, only useful for debugging
-                    mutex_lock();
-                    ipc_shared_data.lh2_calibration.homography_count = config.homography_count;
-                    for (uint32_t idx = 0; idx < config.homography_count; idx++) {
-                        for (uint32_t row = 0; row < 3; row++) {
-                            for (uint32_t col = 0; col < 3; col++) {
-                                ipc_shared_data.lh2_calibration.homographies[idx][row][col] =
-                                    config.homographies[idx][row][col];
-                            }
-                        }
-                    }
-                    mutex_unlock();
                     _app_vars.lh2_calibration_ready = true;
 
                     printf(

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -188,7 +188,7 @@ static void _commit_config_and_reboot(void) {
     // NVIC_SystemReset would only reset this domain and leave the app core
     // with stale Mari / localization state.
     puts("Calibration/config committed to flash, requesting system reset");
-    NRF_IPC_NS->TASKS_SEND[IPC_CHAN_APPLICATION_RESET] = 1;
+    NRF_IPC_NS->TASKS_SEND[IPC_CHAN_SOC_RESET] = 1;
     while (1) { __WFE(); }
 }
 
@@ -202,7 +202,7 @@ int main(void) {
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_RADIO_RX]          = 1 << IPC_CHAN_RADIO_RX;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_START] = 1 << IPC_CHAN_APPLICATION_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_STOP]  = 1 << IPC_CHAN_APPLICATION_STOP;
-    NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_RESET] = 1 << IPC_CHAN_APPLICATION_RESET;
+    NRF_IPC_NS->SEND_CNF[IPC_CHAN_SOC_RESET]         = 1 << IPC_CHAN_SOC_RESET;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_START]         = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_CHUNK]         = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_CALIBRATION_DATA]  = 1 << IPC_CHAN_CALIBRATION_DATA;
@@ -273,7 +273,7 @@ int main(void) {
                     memcpy((uint8_t *)&ipc_shared_data.target_position, req->data, sizeof(position_2d_t));
                     puts("Reset request received");
                     ipc_shared_data.status = SWRMT_APPLICATION_RESETTING;
-                    //NRF_IPC_NS->TASKS_SEND[IPC_CHAN_APPLICATION_RESET] = 1;
+                    //NRF_IPC_NS->TASKS_SEND[IPC_CHAN_SOC_RESET] = 1;
                     break;
                 case SWRMT_MSG_OTA_START:
                 {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -58,6 +58,7 @@ typedef struct {
     uint8_t     computed_hash[SWRMT_OTA_SHA256_LENGTH];
     uint64_t    device_id;
     uint16_t    mari_net_id;
+    bool        mari_initialized;
     int32_t     last_chunk_acked;
     uint32_t    metrics_rx_counter;
     uint32_t    metrics_tx_counter;
@@ -169,12 +170,16 @@ static void _commit_config_and_reboot(void) {
     nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
     nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &_app_vars.config, sizeof(_app_vars.config));
 
-    puts("Calibration/config committed to flash");
+    puts("Calibration/config committed to flash, rebooting netcore");
+    NVIC_SystemReset();
+    while (1) {}
 }
 
 //=========================== main ==============================================
 
 int main(void) {
+    bool self_reboot = (NRF_RESET_NS->RESETREAS & RESET_RESETREAS_LSREQ_Msk) != 0;
+    NRF_RESET_NS->RESETREAS = RESET_RESETREAS_LSREQ_Msk;
 
     _app_vars.device_id = _deviceid();
     _load_config();
@@ -200,6 +205,13 @@ int main(void) {
 
     // Network core must remain on
     ipc_shared_data.net_ready = true;
+
+    // If reboot was self-triggered after calibration commit, bring Mari back automatically
+    if (self_reboot) {
+        puts("Self-reboot detected, auto-initialize Mari");
+        mari_init(MARI_NODE, _app_vars.mari_net_id, &schedule_tiny, &mari_event_callback);
+        _app_vars.mari_initialized = true;
+    }
 
     while (1) {
         __WFE();
@@ -355,7 +367,10 @@ int main(void) {
             switch (_app_vars.ipc_req) {
                 // Mira node functions
                 case IPC_MARI_INIT_REQ:
-                    mari_init(MARI_NODE, _app_vars.mari_net_id, &schedule_tiny, &mari_event_callback);
+                    if (!_app_vars.mari_initialized) {
+                        mari_init(MARI_NODE, _app_vars.mari_net_id, &schedule_tiny, &mari_event_callback);
+                        _app_vars.mari_initialized = true;
+                    }
                     break;
                 case IPC_MARI_NODE_TX_REQ:
                     while (!mari_node_is_connected()) {}

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -135,7 +135,9 @@ static void mari_event_callback(mr_event_t event, mr_event_data_t event_data) {
 }
 
 static void _load_config(void) {
-    // load config into RAM
+    // load config into RAM. On virgin flash every field reads back as 0xFFFFFFFFu;
+    // the has_net_id != 1 check below and the homography_count bounds check
+    // (0 < count <= LH2_BASESTATION_COUNT_MAX) filter that case implicitly.
     const swarmit_config_t *cfg_flash = (const swarmit_config_t *)SWARMIT_NET_CONFIG_START_ADDRESS;
     memcpy(&_app_vars.config, cfg_flash, sizeof(_app_vars.config));
 

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -180,17 +180,19 @@ static void _commit_config_and_reboot(void) {
     nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &_app_vars.config, sizeof(_app_vars.config));
     mr_gpio_clear(&_debug1);
 
-    puts("Calibration/config committed to flash, rebooting netcore");
-    NVIC_SystemReset();
-    while (1) {}
+    // Ask the application core to perform a system-wide reset. App-core
+    // NVIC_SystemReset is a system reset on nRF5340 — both cores come back
+    // up fresh, picking up the new calibration on boot. A net-core-local
+    // NVIC_SystemReset would only reset this domain and leave the app core
+    // with stale Mari / localization state.
+    puts("Calibration/config committed to flash, requesting system reset");
+    NRF_IPC_NS->TASKS_SEND[IPC_CHAN_APPLICATION_RESET] = 1;
+    while (1) { __WFE(); }
 }
 
 //=========================== main ==============================================
 
 int main(void) {
-    bool self_reboot = (NRF_RESET_NS->RESETREAS & RESET_RESETREAS_LSREQ_Msk) != 0;
-    NRF_RESET_NS->RESETREAS = RESET_RESETREAS_LSREQ_Msk;
-
     _app_vars.device_id = _deviceid();
     _load_config();
 
@@ -198,7 +200,7 @@ int main(void) {
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_RADIO_RX]          = 1 << IPC_CHAN_RADIO_RX;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_START] = 1 << IPC_CHAN_APPLICATION_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_STOP]  = 1 << IPC_CHAN_APPLICATION_STOP;
-    //NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_RESET] = 1 << IPC_CHAN_APPLICATION_RESET;
+    NRF_IPC_NS->SEND_CNF[IPC_CHAN_APPLICATION_RESET] = 1 << IPC_CHAN_APPLICATION_RESET;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_START]         = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_CHUNK]         = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_CALIBRATION_DATA]  = 1 << IPC_CHAN_CALIBRATION_DATA;
@@ -221,13 +223,6 @@ int main(void) {
 
     // Network core must remain on
     ipc_shared_data.net_ready = true;
-
-    // If reboot was self-triggered after calibration commit, bring Mari back automatically
-    if (self_reboot) {
-        puts("Self-reboot detected, auto-initialize Mari");
-        mari_init(MARI_NODE, _app_vars.mari_net_id, &schedule_tiny, &mari_event_callback);
-        _app_vars.mari_initialized = true;
-    }
 
     while (1) {
         __WFE();

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -18,6 +18,7 @@
 #include "protocol.h"
 #include "rng.h"
 #include "sha256.h"
+#include "mr_gpio.h"
 
 // Mira includes
 #include "mr_timer_hf.h"
@@ -32,7 +33,7 @@
 #define SWARMIT_NET_CONFIG_PAGE             (127)       // page index for config (last page)
 // Important: select a Network ID according to the specific deployment you are making,
 // see the registry at https://crystalfree.atlassian.net/wiki/spaces/Mari/pages/3324903426/Registry+of+Mari+Network+IDs
-#define SWARMIT_DEFAULT_NET_ID              (0x12AA)
+#define SWARMIT_DEFAULT_NET_ID              (0xA000)
 #define LH2_BASESTATION_COUNT_MAX           (16)
 
 //=========================== variables =========================================
@@ -71,6 +72,9 @@ static swrmt_app_data_t _app_vars = { 0 };
 extern schedule_t schedule_minuscule, schedule_tiny, schedule_small, schedule_huge, schedule_only_beacons, schedule_only_beacons_optimized_scan;
 
 volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_shared_data;
+
+static const mr_gpio_t _debug1 = { .port = 1, .pin = 8 };
+//static const mr_gpio_t _debug2 = { .port = 1, .pin = 10 };
 
 //=========================== functions =========================================
 
@@ -167,8 +171,14 @@ static void _send_status(void) {
 }
 
 static void _commit_config_and_reboot(void) {
+    mr_gpio_set(&_debug1); mr_gpio_clear(&_debug1);
+
+    mr_gpio_set(&_debug1);
     nvmc_page_erase(SWARMIT_NET_CONFIG_PAGE);
+    mr_gpio_clear(&_debug1);
+    mr_gpio_set(&_debug1);
     nvmc_write((const uint32_t *)SWARMIT_NET_CONFIG_START_ADDRESS, &_app_vars.config, sizeof(_app_vars.config));
+    mr_gpio_clear(&_debug1);
 
     puts("Calibration/config committed to flash, rebooting netcore");
     NVIC_SystemReset();
@@ -202,6 +212,12 @@ int main(void) {
     // Configure timer used for timestamping events
     mr_timer_hf_init(NETCORE_MAIN_TIMER);
     mr_timer_hf_set_periodic_us(NETCORE_MAIN_TIMER, 0, 1000000UL, _send_status);
+
+    mr_gpio_init(&_debug1, MR_GPIO_OUT);
+    // mr_gpio_init(&_debug2, MR_GPIO_OUT);
+
+    mr_gpio_set(&_debug1); mr_gpio_clear(&_debug1);
+    // mr_gpio_set(&_debug2); mr_gpio_clear(&_debug2);
 
     // Network core must remain on
     ipc_shared_data.net_ready = true;
@@ -322,23 +338,24 @@ int main(void) {
                 } break;
                 case SWRMT_MSG_LH2_CALIBRATION:
                 {
+                    // mr_gpio_set(&_debug1);
                     if (ipc_shared_data.status != SWRMT_APPLICATION_READY) {
                         break;
                     }
 
                     const swrmt_lh2_calibration_data_t *pkt = (const swrmt_lh2_calibration_data_t *)req->data;
                     if (pkt->homography_index >= LH2_BASESTATION_COUNT_MAX) {
-                        printf("Invalid calibration index %u\n", pkt->homography_index);
+                        // printf("Invalid calibration index %u\n", pkt->homography_index);
                         break;
                     }
                     if (pkt->homography_count == 0 || pkt->homography_count > LH2_BASESTATION_COUNT_MAX) {
-                        printf("Invalid calibration count %u\n", pkt->homography_count);
+                        // printf("Invalid calibration count %u\n", pkt->homography_count);
                         break;
                     }
                     if (pkt->homography_index >= pkt->homography_count) {
-                        printf("Invalid calibration tuple (idx=%u, count=%u)\n",
-                               pkt->homography_index,
-                               pkt->homography_count);
+                        // printf("Invalid calibration tuple (idx=%u, count=%u)\n",
+                        //        pkt->homography_index,
+                        //        pkt->homography_count);
                         break;
                     }
 
@@ -346,11 +363,13 @@ int main(void) {
                     _app_vars.config.homography_count = pkt->homography_count;
                     memcpy(_app_vars.config.homographies[pkt->homography_index], pkt->homography, sizeof(_app_vars.config.homographies[0]));
 
-                    printf(
-                        "Calibration matrix received (count: %u, index: %u)\n",
-                        pkt->homography_count,
-                        pkt->homography_index
-                    );
+                    // printf(
+                    //     "Calibration matrix received (count: %u, index: %u)\n",
+                    //     pkt->homography_count,
+                    //     pkt->homography_index
+                    // );
+
+                    // mr_gpio_set(&_debug1);
 
                     /* User-defined protocol: last matrix index triggers flash commit + reboot. */
                     if (pkt->homography_index == (pkt->homography_count - 1)) {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -84,7 +84,7 @@ static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length
         return;
     }
 
-    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_CALIBRATION_DATA)) {
+    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_LH2_CALIBRATION)) {
         _app_vars.req_received = true;
         return;
     }
@@ -320,7 +320,7 @@ int main(void) {
                     printf("Process OTA chunk request (index: %u, size: %u)\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_size);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_CHUNK] = 1;
                 } break;
-                case SWRMT_MSG_CALIBRATION_DATA:
+                case SWRMT_MSG_LH2_CALIBRATION:
                 {
                     if (ipc_shared_data.status != SWRMT_APPLICATION_READY) {
                         break;

--- a/device/network_core/Source/nvmc.c
+++ b/device/network_core/Source/nvmc.c
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @ingroup bsp_nvmc
+ *
+ * @brief  Implementation of the "nvmc" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <nrf.h>
+#include "nvmc.h"
+
+//=========================== public ==========================================
+
+void nvmc_page_erase(uint32_t page) {
+    const uint32_t *addr = (const uint32_t *)(FLASH_OFFSET + page * FLASH_PAGE_SIZE);
+
+    NRF_NVMC_NS->CONFIG = (NVMC_CONFIG_WEN_Een << NVMC_CONFIG_WEN_Pos);
+    while (!NRF_NVMC_NS->READY) {}
+    *(uint32_t *)addr  = 0xFFFFFFFF;
+    while (!NRF_NVMC_NS->READY) {}
+}
+
+void nvmc_write(const uint32_t *addr, const void *data, size_t len) {
+    uint32_t       *dest_addr = (uint32_t *)addr;
+    const uint32_t *data_addr = data;
+
+    NRF_NVMC_NS->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
+    for (uint32_t i = 0; i < (len >> 2); i++) {
+        while (!NRF_NVMC_NS->READY) {}
+        *dest_addr++ = data_addr[i];
+    }
+    while (!NRF_NVMC_NS->READY) {}
+    NRF_NVMC_NS->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+}

--- a/device/network_core/Source/nvmc.h
+++ b/device/network_core/Source/nvmc.h
@@ -1,0 +1,17 @@
+#ifndef __NVMC_H
+#define __NVMC_H
+
+#include <stdlib.h>
+#include <stdint.h>
+
+//=========================== defines ==========================================
+
+#define FLASH_PAGE_SIZE 2048
+#define FLASH_OFFSET 0x01000000
+
+//=========================== public ===========================================
+
+void nvmc_page_erase(uint32_t page);
+void nvmc_write(const uint32_t *addr, const void *input, size_t len);
+
+#endif

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -38,6 +38,12 @@ typedef enum {
     SWRMT_MSG_OTA_CHUNK_ACK = 0x87,
     SWRMT_MSG_GPIO_EVENT = 0x88,
     SWRMT_MSG_LOG_EVENT = 0x89,
+    // FIXME: we need better namespacing for these messages, for example,
+    // use 0x80 for SwarmIT application type, and then use an internal namespace for SwarmIT messages,
+    // like 0x80.0x01 for SwarmIT status, 0x80.0x02 for SwarmIT start, etc.
+    // for the moment, I am just appending SWRMT_MSG_CALIBRATION_DATA after SWRMT_MESSAGE.
+    SWRMT_MESSAGE = 0xA0, // custom message type
+    SWRMT_MSG_CALIBRATION_DATA = 0xA1,
 } swrmt_message_type_t;
 
 /// Protocol packet type
@@ -81,6 +87,12 @@ typedef struct __attribute__((packed)) {
     uint8_t  sha[8];
     uint8_t  chunk[SWRMT_OTA_CHUNK_SIZE];       ///< Bytes array of the firmware chunk
 } swrmt_ota_chunk_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t homography_count;              ///< number of homography matrices used for localization
+    uint32_t homography_index;              ///< index of the homography matrix to use for localization
+    int32_t homography[3][3];               ///< homography matrix for localization
+} swrmt_lh2_calibration_data_t;
 
 typedef struct __attribute__((packed)) {
     uint8_t port;  ///< Port number of the GPIO

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -41,9 +41,9 @@ typedef enum {
     // FIXME: we need better namespacing for these messages, for example,
     // use 0x80 for SwarmIT application type, and then use an internal namespace for SwarmIT messages,
     // like 0x80.0x01 for SwarmIT status, 0x80.0x02 for SwarmIT start, etc.
-    // for the moment, I am just appending SWRMT_MSG_CALIBRATION_DATA after SWRMT_MESSAGE.
+    // for the moment, I am just appending SWRMT_MSG_LH2_CALIBRATION after SWRMT_MESSAGE.
     SWRMT_MESSAGE = 0xA0, // custom message type
-    SWRMT_MSG_CALIBRATION_DATA = 0xA1,
+    SWRMT_MSG_LH2_CALIBRATION = 0xA1,
 } swrmt_message_type_t;
 
 /// Protocol packet type

--- a/device/network_core/netcore-app.emProject
+++ b/device/network_core/netcore-app.emProject
@@ -11,6 +11,8 @@
     <folder Name="Source">
       <file file_name="Source/ipc.h" />
       <file file_name="Source/main.c" />
+      <file file_name="Source/nvmc.c" />
+      <file file_name="Source/nvmc.h" />
       <file file_name="Source/protocol.c" />
       <file file_name="Source/protocol.h" />
     </folder>

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -345,5 +345,14 @@ def message(ctx, message):
     controller.terminate()
 
 
+@main.command()
+@click.argument("calibration-file", type=click.File(mode="rb"), required=True)
+@click.pass_context
+def calibrate(ctx, calibration_file):
+    """Send calibration data to the robots."""
+    controller = Controller(ctx.obj["settings"])
+    controller.send_calibration_data(bytearray(calibration_file.read()))
+    controller.terminate()
+
 if __name__ == "__main__":
     main(obj={})  # pragma: no cover

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -346,12 +346,12 @@ def message(ctx, message):
 
 
 @main.command()
-@click.argument("calibration-file", type=click.File(mode="rb"), required=True)
+@click.argument("lh2-calibration-file", type=click.File(mode="rb"), required=True)
 @click.pass_context
-def calibrate(ctx, calibration_file):
-    """Send calibration data to the robots."""
+def calibrate_lh2(ctx, lh2_calibration_file):
+    """Send LH2 calibration data to the robots."""
     controller = Controller(ctx.obj["settings"])
-    controller.send_calibration_data(bytearray(calibration_file.read()))
+    controller.send_lh2_calibration(bytearray(lh2_calibration_file.read()))
     controller.terminate()
 
 if __name__ == "__main__":

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -346,13 +346,16 @@ def message(ctx, message):
 
 
 @main.command()
-@click.argument("lh2-calibration-file", type=click.File(mode="rb"), required=True)
+@click.argument(
+    "lh2-calibration-file", type=click.File(mode="rb"), required=True
+)
 @click.pass_context
 def calibrate_lh2(ctx, lh2_calibration_file):
     """Send LH2 calibration data to the robots."""
     controller = Controller(ctx.obj["settings"])
     controller.send_lh2_calibration(bytearray(lh2_calibration_file.read()))
     controller.terminate()
+
 
 if __name__ == "__main__":
     main(obj={})  # pragma: no cover

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -573,10 +573,10 @@ class Controller:
                 print(payload)
                 print(Packet.from_payload(payload).to_bytes())
             # for _ in range(COMMAND_MAX_ATTEMPTS):
-            for _ in range(1):
+            for _ in range(3):
                 # simple strategy to bypass non-reliable link layer, just send the payload multiple times
                 self.send_payload(BROADCAST_ADDRESS, payload)
-                time.sleep(0.2) # give the device some time to process the payload
+                time.sleep(0.1) # give the device some time to process the payload
 
     def _send_start_ota(
         self, device_addr: str, devices_to_flash: set[str], firmware: bytes

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -24,6 +24,7 @@ from swarmit.testbed.adapter import (
 from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.protocol import (
     DeviceType,
+    PayloadCalibrationData,
     PayloadMessage,
     PayloadOTAChunk,
     PayloadOTAStart,
@@ -35,11 +36,11 @@ from swarmit.testbed.protocol import (
 )
 
 CHUNK_SIZE = 128
-COMMAND_TIMEOUT = 6
+COMMAND_TIMEOUT = 1
 COMMAND_MAX_ATTEMPTS = 5
 COMMAND_ATTEMPT_DELAY = 0.7
 INACTIVE_TIMEOUT = 3  # s
-STATUS_TIMEOUT = 5
+STATUS_TIMEOUT = 1
 MONITOR_TIMEOUT = 60  # s
 OTA_MAX_RETRIES_DEFAULT = 10
 OTA_ACK_TIMEOUT_DEFAULT = 0.7
@@ -344,6 +345,9 @@ class Controller:
 
     def send_payload(self, destination: int, payload: Payload):
         """Send a frame to the devices."""
+        print(f"Sending payload to {destination}...")
+        print(payload)
+        print(Packet.from_payload(payload).to_bytes())
         self.interface.send_payload(destination, payload)
 
     def on_frame_received(self, header, packet: Packet):
@@ -419,6 +423,9 @@ class Controller:
 
     def _send_start(self, device_addr: str):
         payload = PayloadStart()
+        print(f"Sending start to {device_addr}...")
+        print(payload)
+        print(Packet.from_payload(payload).to_bytes())
         self.send_payload(int(device_addr, 16), payload)
 
     def start(self, devices=None, timeout=COMMAND_TIMEOUT):
@@ -518,6 +525,32 @@ class Controller:
                 if addr not in running_devices:
                     continue
                 self._send_message(int(addr, 16), message)
+
+    def send_calibration_data(self, calibration_file: bytes):
+        running_devices = self.running_devices
+
+        # TODO: handle the file
+
+        # DEBUG: use a dummy calibration data
+        payload = PayloadCalibrationData(
+            homography_count=1,
+            homography_index=0,
+            homography=(
+                    b'\xff\xff\xff\xff'  # -1
+                    b'\xe7\x03\x00\x00'  # 999
+                    b'\x01\x00\x00\x00'  # 1
+                    b'\x98\xb1\x01\x00'  # 111000
+                    b'\x09\x00\x00\x00'  # 9
+                    b'\x68\x4e\xfe\xff'  # -111000
+                    b'\x01\x00\x00\x00'  # 1
+                    b'\x58\x3e\x0f\x00'  # 999000
+                    b'\xff\xff\xff\xff'  # -1
+            ),
+        )
+        print(f"Sending calibration data to {BROADCAST_ADDRESS}...")
+        print(payload)
+        print(Packet.from_payload(payload).to_bytes())
+        self.send_payload(BROADCAST_ADDRESS, payload)
 
     def _send_start_ota(
         self, device_addr: str, devices_to_flash: set[str], firmware: bytes

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -526,7 +526,10 @@ class Controller:
             raise ValueError("Calibration file is empty")
 
         # Supported format: 1-byte count + N * 36 bytes
-        if len(calibration_file) < 1 or (len(calibration_file) - 1) % matrix_size != 0:
+        if (
+            len(calibration_file) < 1
+            or (len(calibration_file) - 1) % matrix_size != 0
+        ):
             raise ValueError(
                 f"Invalid calibration file size: expected 1+N*{matrix_size} bytes (count byte + matrices)"
             )
@@ -539,7 +542,9 @@ class Controller:
                 "Invalid calibration file: count byte does not match matrix payload length"
             )
         if homography_count == 0:
-            raise ValueError("Invalid calibration file: homography count cannot be zero")
+            raise ValueError(
+                "Invalid calibration file: homography count cannot be zero"
+            )
 
         if homography_count > 16:
             raise ValueError(
@@ -548,9 +553,13 @@ class Controller:
 
         ready_devices = self.ready_devices
         if not ready_devices:
-            print(f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}...")
+            print(
+                f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}..."
+            )
         else:
-            print(f"Sending {homography_count} calibration matrix/matrices to {len(ready_devices)} devices: {str(ready_devices)}...")
+            print(
+                f"Sending {homography_count} calibration matrix/matrices to {len(ready_devices)} devices: {str(ready_devices)}..."
+            )
 
         for homography_index in range(homography_count):
             print(f"Sending calibration matrix {homography_index}...")
@@ -571,7 +580,9 @@ class Controller:
                 else:
                     for device_addr in ready_devices:
                         self.send_payload(int(device_addr, 16), payload)
-                time.sleep(0.1) # give the device some time to process the payload
+                time.sleep(
+                    0.1
+                )  # give the device some time to process the payload
 
     def _send_start_ota(
         self, device_addr: str, devices_to_flash: set[str], firmware: bytes

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -345,9 +345,6 @@ class Controller:
 
     def send_payload(self, destination: int, payload: Payload):
         """Send a frame to the devices."""
-        print(f"Sending payload to {destination}...")
-        print(payload.homography)
-        # print(Packet.from_payload(payload).to_bytes())
         self.interface.send_payload(destination, payload)
 
     def on_frame_received(self, header, packet: Packet):
@@ -423,9 +420,6 @@ class Controller:
 
     def _send_start(self, device_addr: str):
         payload = PayloadStart()
-        print(f"Sending start to {device_addr}...")
-        print(payload)
-        print(Packet.from_payload(payload).to_bytes())
         self.send_payload(int(device_addr, 16), payload)
 
     def start(self, devices=None, timeout=COMMAND_TIMEOUT):
@@ -526,7 +520,7 @@ class Controller:
                     continue
                 self._send_message(int(addr, 16), message)
 
-    def send_calibration_data(self, calibration_file: bytes):
+    def send_lh2_calibration(self, calibration_file: bytes):
         ready_devices = self.ready_devices
         if not ready_devices:
             print("No ready devices found, aborting")
@@ -560,8 +554,6 @@ class Controller:
         print(f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}...")
         for homography_index in range(homography_count):
             print(f"Sending calibration matrix {homography_index}...")
-            # if homography_index == 0:
-            #     continue
             start = homography_index * matrix_size
             end = start + matrix_size
             payload = PayloadCalibrationData(
@@ -572,8 +564,7 @@ class Controller:
             if self.settings.verbose:
                 print(payload)
                 print(Packet.from_payload(payload).to_bytes())
-            # for _ in range(COMMAND_MAX_ATTEMPTS):
-            for _ in range(3):
+            for _ in range(COMMAND_MAX_ATTEMPTS):
                 # simple strategy to bypass non-reliable link layer, just send the payload multiple times
                 self.send_payload(BROADCAST_ADDRESS, payload)
                 time.sleep(0.1) # give the device some time to process the payload

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -581,7 +581,7 @@ class Controller:
                     for device_addr in ready_devices:
                         self.send_payload(int(device_addr, 16), payload)
                 time.sleep(
-                    0.1
+                    0.3
                 )  # give the device some time to process the payload
 
     def _send_start_ota(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -346,8 +346,8 @@ class Controller:
     def send_payload(self, destination: int, payload: Payload):
         """Send a frame to the devices."""
         print(f"Sending payload to {destination}...")
-        print(payload)
-        print(Packet.from_payload(payload).to_bytes())
+        print(payload.homography)
+        # print(Packet.from_payload(payload).to_bytes())
         self.interface.send_payload(destination, payload)
 
     def on_frame_received(self, header, packet: Packet):
@@ -527,30 +527,56 @@ class Controller:
                 self._send_message(int(addr, 16), message)
 
     def send_calibration_data(self, calibration_file: bytes):
-        running_devices = self.running_devices
+        ready_devices = self.ready_devices
+        if not ready_devices:
+            print("No ready devices found, aborting")
+            return
 
-        # TODO: handle the file
+        matrix_size = 3 * 3 * 4  # 3x3, each element is 4 bytes (int32_t)
+        if not calibration_file:
+            raise ValueError("Calibration file is empty")
 
-        # DEBUG: use a dummy calibration data
-        payload = PayloadCalibrationData(
-            homography_count=1,
-            homography_index=0,
-            homography=(
-                    b'\xff\xff\xff\xff'  # -1
-                    b'\xe7\x03\x00\x00'  # 999
-                    b'\x01\x00\x00\x00'  # 1
-                    b'\x98\xb1\x01\x00'  # 111000
-                    b'\x09\x00\x00\x00'  # 9
-                    b'\x68\x4e\xfe\xff'  # -111000
-                    b'\x01\x00\x00\x00'  # 1
-                    b'\x58\x3e\x0f\x00'  # 999000
-                    b'\xff\xff\xff\xff'  # -1
-            ),
-        )
-        print(f"Sending calibration data to {BROADCAST_ADDRESS}...")
-        print(payload)
-        print(Packet.from_payload(payload).to_bytes())
-        self.send_payload(BROADCAST_ADDRESS, payload)
+        # Supported format: 1-byte count + N * 36 bytes
+        if len(calibration_file) < 1 or (len(calibration_file) - 1) % matrix_size != 0:
+            raise ValueError(
+                f"Invalid calibration file size: expected 1+N*{matrix_size} bytes (count byte + matrices)"
+            )
+
+        homography_count = calibration_file[0]
+        matrices_bytes = calibration_file[1:]
+        expected_count = len(matrices_bytes) // matrix_size
+        if homography_count != expected_count:
+            raise ValueError(
+                "Invalid calibration file: count byte does not match matrix payload length"
+            )
+        if homography_count == 0:
+            raise ValueError("Invalid calibration file: homography count cannot be zero")
+
+        if homography_count > 16:
+            raise ValueError(
+                "Invalid calibration file: homography count exceeds LH2 limit (16)"
+            )
+
+        print(f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}...")
+        for homography_index in range(homography_count):
+            print(f"Sending calibration matrix {homography_index}...")
+            # if homography_index == 0:
+            #     continue
+            start = homography_index * matrix_size
+            end = start + matrix_size
+            payload = PayloadCalibrationData(
+                homography_count=homography_count,
+                homography_index=homography_index,
+                homography=matrices_bytes[start:end],
+            )
+            if self.settings.verbose:
+                print(payload)
+                print(Packet.from_payload(payload).to_bytes())
+            # for _ in range(COMMAND_MAX_ATTEMPTS):
+            for _ in range(1):
+                # simple strategy to bypass non-reliable link layer, just send the payload multiple times
+                self.send_payload(BROADCAST_ADDRESS, payload)
+                time.sleep(0.2) # give the device some time to process the payload
 
     def _send_start_ota(
         self, device_addr: str, devices_to_flash: set[str], firmware: bytes

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -36,11 +36,11 @@ from swarmit.testbed.protocol import (
 )
 
 CHUNK_SIZE = 128
-COMMAND_TIMEOUT = 1
+COMMAND_TIMEOUT = 2
 COMMAND_MAX_ATTEMPTS = 5
 COMMAND_ATTEMPT_DELAY = 0.7
 INACTIVE_TIMEOUT = 3  # s
-STATUS_TIMEOUT = 1
+STATUS_TIMEOUT = 2
 MONITOR_TIMEOUT = 60  # s
 OTA_MAX_RETRIES_DEFAULT = 10
 OTA_ACK_TIMEOUT_DEFAULT = 0.7
@@ -521,11 +521,6 @@ class Controller:
                 self._send_message(int(addr, 16), message)
 
     def send_lh2_calibration(self, calibration_file: bytes):
-        ready_devices = self.ready_devices
-        if not ready_devices:
-            print("No ready devices found, aborting")
-            return
-
         matrix_size = 3 * 3 * 4  # 3x3, each element is 4 bytes (int32_t)
         if not calibration_file:
             raise ValueError("Calibration file is empty")
@@ -551,7 +546,12 @@ class Controller:
                 "Invalid calibration file: homography count exceeds LH2 limit (16)"
             )
 
-        print(f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}...")
+        ready_devices = self.ready_devices
+        if not ready_devices:
+            print(f"Sending {homography_count} calibration matrix/matrices to {BROADCAST_ADDRESS}...")
+        else:
+            print(f"Sending {homography_count} calibration matrix/matrices to {len(ready_devices)} devices: {str(ready_devices)}...")
+
         for homography_index in range(homography_count):
             print(f"Sending calibration matrix {homography_index}...")
             start = homography_index * matrix_size
@@ -566,7 +566,11 @@ class Controller:
                 print(Packet.from_payload(payload).to_bytes())
             for _ in range(COMMAND_MAX_ATTEMPTS):
                 # simple strategy to bypass non-reliable link layer, just send the payload multiple times
-                self.send_payload(BROADCAST_ADDRESS, payload)
+                if not ready_devices:
+                    self.send_payload(BROADCAST_ADDRESS, payload)
+                else:
+                    for device_addr in ready_devices:
+                        self.send_payload(int(device_addr, 16), payload)
                 time.sleep(0.1) # give the device some time to process the payload
 
     def _send_start_ota(

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -52,7 +52,7 @@ class PayloadType(IntEnum):
     SWARMIT_MESSAGE = 0xA0
 
     # SwarmIT calibration data
-    SWARMIT_CALIBRATION_DATA = 0xA1
+    SWARMIT_LH2_CALIBRATION = 0xA1
 
     # Marilib metrics probe
     METRICS_PROBE = MariDefaultPayloadType.METRICS_PROBE
@@ -240,5 +240,5 @@ register_parser(PayloadType.SWARMIT_OTA_START_ACK, PayloadOTAStartAck)
 register_parser(PayloadType.SWARMIT_OTA_CHUNK_ACK, PayloadOTAChunkAck)
 register_parser(PayloadType.SWARMIT_EVENT_LOG, PayloadEvent)
 register_parser(PayloadType.SWARMIT_MESSAGE, PayloadMessage)
-register_parser(PayloadType.SWARMIT_CALIBRATION_DATA, PayloadCalibrationData)
+register_parser(PayloadType.SWARMIT_LH2_CALIBRATION, PayloadCalibrationData)
 register_parser(PayloadType.METRICS_PROBE, MetricsProbePayload)

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -160,15 +160,25 @@ class PayloadCalibrationData(Payload):
 
     metadata: list[PayloadFieldMetadata] = dataclasses.field(
         default_factory=lambda: [
-            PayloadFieldMetadata(name="homography_count", disp="count", length=4),
-            PayloadFieldMetadata(name="homography_index", disp="idx", length=4),
-            PayloadFieldMetadata(name="homography", type_=bytes, length=3*3*4),
+            PayloadFieldMetadata(
+                name="homography_count", disp="count", length=4
+            ),
+            PayloadFieldMetadata(
+                name="homography_index", disp="idx", length=4
+            ),
+            PayloadFieldMetadata(
+                name="homography", type_=bytes, length=3 * 3 * 4
+            ),
         ]
     )
 
-    homography_count: int = 0 # number of homography matrices used for localization
-    homography_index: int = 0 # index of the homography matrix to be sent
-    homography: bytes = dataclasses.field(default_factory=lambda: bytearray) # 9x4 bytes of the homography matrix
+    homography_count: int = (
+        0  # number of homography matrices used for localization
+    )
+    homography_index: int = 0  # index of the homography matrix to be sent
+    homography: bytes = dataclasses.field(
+        default_factory=lambda: bytearray
+    )  # 9x4 bytes of the homography matrix
 
 
 @dataclass

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -51,6 +51,9 @@ class PayloadType(IntEnum):
     # Custom messages
     SWARMIT_MESSAGE = 0xA0
 
+    # SwarmIT calibration data
+    SWARMIT_CALIBRATION_DATA = 0xA1
+
     # Marilib metrics probe
     METRICS_PROBE = MariDefaultPayloadType.METRICS_PROBE
 
@@ -152,6 +155,23 @@ class PayloadOTAChunk(Payload):
 
 
 @dataclass
+class PayloadCalibrationData(Payload):
+    """Dataclass that holds a calibration data packet."""
+
+    metadata: list[PayloadFieldMetadata] = dataclasses.field(
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="homography_count", disp="count", length=4),
+            PayloadFieldMetadata(name="homography_index", disp="idx", length=4),
+            PayloadFieldMetadata(name="homography", type_=bytes, length=3*3*4),
+        ]
+    )
+
+    homography_count: int = 0 # number of homography matrices used for localization
+    homography_index: int = 0 # index of the homography matrix to be sent
+    homography: bytes = dataclasses.field(default_factory=lambda: bytearray) # 9x4 bytes of the homography matrix
+
+
+@dataclass
 class PayloadOTAStartAck(Payload):
     """Dataclass that holds an application OTA start ACK notification packet."""
 
@@ -220,4 +240,5 @@ register_parser(PayloadType.SWARMIT_OTA_START_ACK, PayloadOTAStartAck)
 register_parser(PayloadType.SWARMIT_OTA_CHUNK_ACK, PayloadOTAChunkAck)
 register_parser(PayloadType.SWARMIT_EVENT_LOG, PayloadEvent)
 register_parser(PayloadType.SWARMIT_MESSAGE, PayloadMessage)
+register_parser(PayloadType.SWARMIT_CALIBRATION_DATA, PayloadCalibrationData)
 register_parser(PayloadType.METRICS_PROBE, MetricsProbePayload)

--- a/swarmit/tests/test_cli.py
+++ b/swarmit/tests/test_cli.py
@@ -31,13 +31,14 @@ Options:
   -h, --help                  Show this message and exit.
 
 Commands:
-  flash    Flash a firmware to the robots.
-  message  Send a custom text message to the robots.
-  monitor  Monitor running applications.
-  reset    Reset robots locations.
-  start    Start the user application.
-  status   Print current status of the robots.
-  stop     Stop the user application.
+  calibrate-lh2  Send LH2 calibration data to the robots.
+  flash          Flash a firmware to the robots.
+  message        Send a custom text message to the robots.
+  monitor        Monitor running applications.
+  reset          Reset robots locations.
+  start          Start the user application.
+  status         Print current status of the robots.
+  stop           Stop the user application.
 """
 
 

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -1,7 +1,8 @@
 import logging
 import time
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
+import pytest
 from marilib.model import GatewayInfo, MariGateway
 
 from swarmit.testbed.controller import (
@@ -433,6 +434,100 @@ def test_controller_send_message_broadcast(capsys):
     out, _ = capsys.readouterr()
     for node in ["00000001", "00000002"]:
         assert f"Node {node} received message: Hello robot!" in out
+
+
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+@patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
+def test_controller_send_calibration_data_from_file_bytes():
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    matrix_0 = bytes(range(36))
+    matrix_1 = bytes(range(36, 72))
+    calibration_file = bytes([2]) + matrix_0 + matrix_1
+
+    with (
+        patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
+        patch.object(controller, "send_payload") as send_payload_mock,
+    ):
+        controller.send_calibration_data(calibration_file)
+
+    assert send_payload_mock.call_count == 2
+    first_call = send_payload_mock.call_args_list[0].args
+    second_call = send_payload_mock.call_args_list[1].args
+
+    assert first_call[0] == 0xFFFFFFFFFFFFFFFF
+    assert first_call[1].homography_count == 2
+    assert first_call[1].homography_index == 0
+    assert first_call[1].homography == matrix_0
+
+    assert second_call[0] == 0xFFFFFFFFFFFFFFFF
+    assert second_call[1].homography_count == 2
+    assert second_call[1].homography_index == 1
+    assert second_call[1].homography == matrix_1
+    controller.terminate()
+
+
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+@patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
+def test_controller_send_calibration_data_from_legacy_out_format():
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    matrix = bytes(range(36))
+    calibration_file = bytes([1]) + matrix
+
+    with (
+        patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
+        patch.object(controller, "send_payload") as send_payload_mock,
+    ):
+        controller.send_calibration_data(calibration_file)
+
+    assert send_payload_mock.call_count == 1
+    call = send_payload_mock.call_args_list[0].args
+    assert call[0] == 0xFFFFFFFFFFFFFFFF
+    assert call[1].homography_count == 1
+    assert call[1].homography_index == 0
+    assert call[1].homography == matrix
+    controller.terminate()
+
+
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+@patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
+def test_controller_send_calibration_data_invalid_size():
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+        with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
+            controller.send_calibration_data(b"\x00" * 35)
+    controller.terminate()
+
+
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+@patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
+def test_controller_send_calibration_data_legacy_count_mismatch():
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    calibration_file = bytes([2]) + bytes(range(36))
+    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+        with pytest.raises(ValueError, match="count byte does not match"):
+            controller.send_calibration_data(calibration_file)
+    controller.terminate()
+
+
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+@patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
+def test_controller_send_calibration_data_raw_format_rejected():
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    raw_matrix_only = bytes(range(36))
+    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+        with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
+            controller.send_calibration_data(raw_matrix_only)
+    controller.terminate()
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -446,22 +446,27 @@ def test_controller_send_lh2_calibration_from_file_bytes():
     matrix_1 = bytes(range(36, 72))
     calibration_file = bytes([2]) + matrix_0 + matrix_1
 
-    with (
-        patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
-        patch.object(controller, "send_payload") as send_payload_mock,
+    with patch.object(
+        type(controller),
+        "ready_devices",
+        new_callable=PropertyMock,
+        return_value=["00000001"],
     ):
-        controller.send_lh2_calibration(calibration_file)
+        with patch.object(controller, "send_payload") as send_payload_mock:
+            controller.send_lh2_calibration(calibration_file)
 
     assert send_payload_mock.call_count == 2
     first_call = send_payload_mock.call_args_list[0].args
     second_call = send_payload_mock.call_args_list[1].args
 
-    assert first_call[0] == 0xFFFFFFFFFFFFFFFF
+    # ready_devices is set so the controller sends unicast to each device,
+    # not broadcast. "00000001" → 0x1.
+    assert first_call[0] == 0x1
     assert first_call[1].homography_count == 2
     assert first_call[1].homography_index == 0
     assert first_call[1].homography == matrix_0
 
-    assert second_call[0] == 0xFFFFFFFFFFFFFFFF
+    assert second_call[0] == 0x1
     assert second_call[1].homography_count == 2
     assert second_call[1].homography_index == 1
     assert second_call[1].homography == matrix_1
@@ -477,15 +482,19 @@ def test_controller_send_lh2_calibration_from_legacy_out_format():
     matrix = bytes(range(36))
     calibration_file = bytes([1]) + matrix
 
-    with (
-        patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
-        patch.object(controller, "send_payload") as send_payload_mock,
+    with patch.object(
+        type(controller),
+        "ready_devices",
+        new_callable=PropertyMock,
+        return_value=["00000001"],
     ):
-        controller.send_lh2_calibration(calibration_file)
+        with patch.object(controller, "send_payload") as send_payload_mock:
+            controller.send_lh2_calibration(calibration_file)
 
     assert send_payload_mock.call_count == 1
     call = send_payload_mock.call_args_list[0].args
-    assert call[0] == 0xFFFFFFFFFFFFFFFF
+    # ready_devices is set → unicast to "00000001" → 0x1.
+    assert call[0] == 0x1
     assert call[1].homography_count == 1
     assert call[1].homography_index == 0
     assert call[1].homography == matrix
@@ -498,7 +507,12 @@ def test_controller_send_lh2_calibration_from_legacy_out_format():
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
 def test_controller_send_lh2_calibration_invalid_size():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
-    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+    with patch.object(
+        type(controller),
+        "ready_devices",
+        new_callable=PropertyMock,
+        return_value=["00000001"],
+    ):
         with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
             controller.send_lh2_calibration(b"\x00" * 35)
     controller.terminate()
@@ -511,7 +525,12 @@ def test_controller_send_lh2_calibration_invalid_size():
 def test_controller_send_lh2_calibration_legacy_count_mismatch():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     calibration_file = bytes([2]) + bytes(range(36))
-    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+    with patch.object(
+        type(controller),
+        "ready_devices",
+        new_callable=PropertyMock,
+        return_value=["00000001"],
+    ):
         with pytest.raises(ValueError, match="count byte does not match"):
             controller.send_lh2_calibration(calibration_file)
     controller.terminate()
@@ -524,7 +543,12 @@ def test_controller_send_lh2_calibration_legacy_count_mismatch():
 def test_controller_send_lh2_calibration_raw_format_rejected():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     raw_matrix_only = bytes(range(36))
-    with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
+    with patch.object(
+        type(controller),
+        "ready_devices",
+        new_callable=PropertyMock,
+        return_value=["00000001"],
+    ):
         with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
             controller.send_lh2_calibration(raw_matrix_only)
     controller.terminate()

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -440,7 +440,7 @@ def test_controller_send_message_broadcast(capsys):
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
-def test_controller_send_calibration_data_from_file_bytes():
+def test_controller_send_lh2_calibration_from_file_bytes():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     matrix_0 = bytes(range(36))
     matrix_1 = bytes(range(36, 72))
@@ -450,7 +450,7 @@ def test_controller_send_calibration_data_from_file_bytes():
         patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
         patch.object(controller, "send_payload") as send_payload_mock,
     ):
-        controller.send_calibration_data(calibration_file)
+        controller.send_lh2_calibration(calibration_file)
 
     assert send_payload_mock.call_count == 2
     first_call = send_payload_mock.call_args_list[0].args
@@ -472,7 +472,7 @@ def test_controller_send_calibration_data_from_file_bytes():
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
-def test_controller_send_calibration_data_from_legacy_out_format():
+def test_controller_send_lh2_calibration_from_legacy_out_format():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     matrix = bytes(range(36))
     calibration_file = bytes([1]) + matrix
@@ -481,7 +481,7 @@ def test_controller_send_calibration_data_from_legacy_out_format():
         patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]),
         patch.object(controller, "send_payload") as send_payload_mock,
     ):
-        controller.send_calibration_data(calibration_file)
+        controller.send_lh2_calibration(calibration_file)
 
     assert send_payload_mock.call_count == 1
     call = send_payload_mock.call_args_list[0].args
@@ -496,11 +496,11 @@ def test_controller_send_calibration_data_from_legacy_out_format():
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
-def test_controller_send_calibration_data_invalid_size():
+def test_controller_send_lh2_calibration_invalid_size():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
         with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
-            controller.send_calibration_data(b"\x00" * 35)
+            controller.send_lh2_calibration(b"\x00" * 35)
     controller.terminate()
 
 
@@ -508,12 +508,12 @@ def test_controller_send_calibration_data_invalid_size():
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
-def test_controller_send_calibration_data_legacy_count_mismatch():
+def test_controller_send_lh2_calibration_legacy_count_mismatch():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     calibration_file = bytes([2]) + bytes(range(36))
     with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
         with pytest.raises(ValueError, match="count byte does not match"):
-            controller.send_calibration_data(calibration_file)
+            controller.send_lh2_calibration(calibration_file)
     controller.terminate()
 
 
@@ -521,12 +521,12 @@ def test_controller_send_calibration_data_legacy_count_mismatch():
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
 @patch("swarmit.testbed.controller.COMMAND_MAX_ATTEMPTS", 1)
-def test_controller_send_calibration_data_raw_format_rejected():
+def test_controller_send_lh2_calibration_raw_format_rejected():
     controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     raw_matrix_only = bytes(range(36))
     with patch.object(type(controller), "ready_devices", new_callable=PropertyMock, return_value=["00000001"]):
         with pytest.raises(ValueError, match="expected 1\\+N\\*36 bytes"):
-            controller.send_calibration_data(raw_matrix_only)
+            controller.send_lh2_calibration(raw_matrix_only)
     controller.terminate()
 
 


### PR DESCRIPTION
The plan:
1. `swarmit -c ../swarmit-argus.toml -n A001 calibrate ~/.dotbot/calibration.out`
2. the device receives it and stores on flash
3. once it's done, the device needs to be rebooted for the new calibration to apply

Regarding the transfer, my approach is to send the homography matrices one by one, the packets will be like this:
- count: the total count of homography matrices
- index: the index of the current homography matrix
- homography: the actual matrix data with 9 int32_t items

The calibration is stateless on the device side: every time it receives a calibration packet, it writes `count` to the flash config area, as well as the the `homography` matrix (at the correct ìndex` as indicated in the packet). This means that the same `count` will be written several times (one for each packet), but there is no harm on that.

---

Update: this now works! Remains to be tested with a real lighthouse though.

How to test the remote calibration update:

```
swarmit -c ../swarmit-argus.toml calibrate-lh2 <calibration file>
```

I also used these snippets to generate some dummy calibration files:

```bash
python3 -c "import struct; m=[[1,1,1],[111000,9,-111000],[1,999000,-1]]; \
  open('calib111.bin','wb').\
  write(bytes([1]) + b''.join(struct.pack('<i',v) for r in m for v in r))"
# generates a matrix like [[1,1,1],[111000,9,-111000],[1,999000,-1]]
```

```bash
python3 -c "import struct; mats=[[[k,k,k],[k,k,k],[k,k,k]] for k in (1,2,3,4)]; \
  open('calib1234.bin','wb').\
  write(bytes([len(mats)]) + b''.join(struct.pack('<i',v) for m in mats for r in m for v in r))"
# generates 4 matrices like [[k,k,k],[k,k,k],[k,k,k]]
```