### PR TITLE
Bump mari and rewrite internal paths

### DIFF
--- a/swarmit-bootloader-nrf52840dk.emProject
+++ b/swarmit-bootloader-nrf52840dk.emProject
@@ -24,7 +24,7 @@
     build_treat_warnings_as_errors="Yes"
     c_only_additional_options="-Wno-missing-prototypes;-Wno-strict-prototypes"
     c_preprocessor_definitions="ARM_MATH_CM4;NRF52840_XXAA;__NRF_FAMILY;CONFIG_NFCT_PINS_AS_GPIOS;BOARD_NRF52840DK;USE_MARI"
-    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(SolutionDir)/../../mari/mari;$(SolutionDir)/../../mari/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
+    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(SolutionDir)/../../mari/firmware/mari;$(SolutionDir)/../../mari/firmware/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
     clang_machine_outliner="Yes"
     compiler_color_diagnostics="Yes"
     debug_register_definition_file="$(ProjectDir)/Setup/nrf52840_Registers.xml"
@@ -67,6 +67,6 @@
   <import file_name="dotbot-libs/bsp/bsp.emProject" />
   <import file_name="dotbot-libs/crypto/crypto.emProject" />
   <import file_name="dotbot-libs/drv/drv.emProject" />
-  <import file_name="mari/mari/mari.emProject" />
-  <import file_name="mari/drv/drv.emProject" />
+  <import file_name="mari/firmware/mari/mari.emProject" />
+  <import file_name="mari/firmware/drv/drv.emProject" />
 </solution>

--- a/swarmit-netcore.emProject
+++ b/swarmit-netcore.emProject
@@ -27,7 +27,7 @@
     c_additional_options="-Wall;-Wextra;-Wunused-variable;-Wuninitialized;-Wmissing-field-initializers;-Wundef;-ffunction-sections;-fdata-sections"
     c_only_additional_options="-Wno-missing-prototypes"
     c_preprocessor_definitions="ARM_MATH_ARMV8MML;NRF5340_XXAA;NRF_NETWORK;__NRF_FAMILY;__NO_FPU_ENABLE;FLASH_PLACEMENT=1;USE_LH2"
-    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(SolutionDir)/../../mari/mari;$(SolutionDir)/../../mari/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
+    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(SolutionDir)/../../mari/firmware/mari;$(SolutionDir)/../../mari/firmware/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
     debug_register_definition_file="$(ProjectDir)/Setup/nrf5340_network_Registers.xml"
     debug_stack_pointer_start="__stack_end__"
     debug_start_from_entry_point_symbol="No"
@@ -66,6 +66,6 @@
   <import file_name="dotbot-libs/bsp/bsp.emProject" />
   <import file_name="dotbot-libs/drv/drv.emProject" />
   <import file_name="dotbot-libs/crypto/crypto.emProject" />
-  <import file_name="mari/mari/mari.emProject" />
-  <import file_name="mari/drv/drv.emProject" />
+  <import file_name="mari/firmware/mari/mari.emProject" />
+  <import file_name="mari/firmware/drv/drv.emProject" />
 </solution>


### PR DESCRIPTION
Mari develop absorbed marilib (https://github.com/DotBots/mari/pull/152) and moved firmware sources under firmware/; update the two .emProject files that traverse mari's tree.