### PR TITLE
swarmit: bump dotbot-libs to develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dist/
 # coverage
 coverage.xml
 .coverage
+
+.DS_Store
+*.swp


### PR DESCRIPTION
## Summary
Bumps the `dotbot-libs` submodule from `3fce29b` (`0.1.0-5`) to `719b504` (current `develop` tip). **44 commits jumped** — the submodule had been stuck at the `0.1.0-5` pin since April 2025 while `DotBot-firmware` and `dotbot-lh2-calibration` had been tracking newer dotbot-libs versions.

## What's in those 44 commits

Most operationally relevant:

- **~10 commits in `bsp/lh2/`** — ISR re-arming, ring-buffer drain semantics, masked-while-reading patterns, bit-packing optimization. **`bsp/lh2.h` API surface is unchanged** (verified: `git diff 3fce29b..719b504 -- bsp/lh2.h` is empty), so swarmit compiles cleanly. But the **runtime behavior** of `db_lh2_*` may differ in edge cases — that's exactly the kind of change a lighthouse rig is the only honest test for.
- `drv/control_loop/` — new module + many iterations. Swarmit does not include `control_loop.h`, so no impact.
- `drv/protocol.h` — dropped z-coordinate from `protocol_lh2_location_t`. Swarmit has its own local `protocol.h` copy (`device/bootloader/Source/protocol.h`) which is also `{x, y}`, so no impact.
- `bsp/conf/` updates — touched v1, nrf52833dk, nrf52840dk configs only. Swarmit targets dotbot-v3.
- **`drv/rgbled`** — SCK disconnected (DotBots/DotBot-libs#19). Cosmetic fix for LED3-stuck-on; swarmit doesn't call `db_rgbled_*` directly.

## Compile-risk verdict
Structurally safe (no signature changes affect swarmit's call sites).

## Runtime-risk verdict
LH2 HIL validation recommended before merge — the `bsp/lh2` internal changes touch ISR timing and sample-loss recovery paths. Validation plan: flash a swarmit bootloader from this branch, run a sandbox app that calls `swarmit_localization_get_position`, verify positions stay sensible.