### PR TITLE
Add opt-in CMake build for the bootloader and netcore firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,25 +51,15 @@ add_link_options(
     -nostartfiles
 )
 
-# ── Nordic MDK + ARM CMSIS-Core via FetchContent ─────────────────────
-include(FetchContent)
-
-FetchContent_Declare(nrfx
-    GIT_REPOSITORY https://github.com/NordicSemiconductor/nrfx.git
-    GIT_TAG        v3.5.0
-    GIT_SHALLOW    TRUE
-)
-FetchContent_Declare(cmsis_core
-    GIT_REPOSITORY https://github.com/ARM-software/CMSIS_5.git
-    GIT_TAG        5.9.0
-    GIT_SHALLOW    TRUE
-)
-FetchContent_MakeAvailable(nrfx cmsis_core)
-
-set(NRFX_MDK_INCLUDE   ${nrfx_SOURCE_DIR}/mdk                       CACHE INTERNAL "Nordic MDK headers")
-set(CMSIS_CORE_INCLUDE ${cmsis_core_SOURCE_DIR}/CMSIS/Core/Include  CACHE INTERNAL "ARM CMSIS-Core headers")
-
-# ── dotbot-libs ──────────────────────────────────────────────────────
+# ── dotbot-libs (owns Nordic + CMSIS FetchContent) ───────────────────
+# dotbot-libs's CMakeLists owns the nrfx + CMSIS_5 FetchContent and
+# exposes two INTERFACE targets:
+#   * `dotbot_libs`   — BSP + drivers + pure-C startup (cpu.c)
+#   * `dotbot_nordic` — only the Nordic + ARM headers
+#
+# The bootloader and netcore here ship their OWN System/startup.c, so
+# they link `dotbot_nordic` (headers only) instead of `dotbot_libs`
+# (which would double-define Reset_Handler / vector tables).
 set(DOTBOT_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/dotbot-libs"
     CACHE PATH "Path to dotbot-libs. Defaults to the bundled submodule.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,103 @@
+# swarmit — opt-in CMake build for the device-side firmware
+# (bootloader + netcore). SES (.emProject) projects continue to work
+# unchanged. Python tooling is unaffected (and not driven by CMake).
+#
+# Quick start:
+#
+#   # Use bundled submodules (default — what CI does):
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake -G Ninja
+#   cmake --build build
+#
+#   # Cross-repo iteration: override paths to local checkouts.
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake \
+#         -DDOTBOT_LIBS=/path/to/DotBot-libs \
+#         -DMARI=/path/to/mari \
+#         -G Ninja
+#
+# Two targets:
+#   - bootloader  (secure side, nRF5340 app core, hard float, emits
+#                  cmse_implib.a for non-secure consumers)
+#   - netcore     (nRF5340 net core, soft float, links mari + dotbot-libs
+#                  netcore variants)
+
+cmake_minimum_required(VERSION 3.20)
+
+project(swarmit-device
+    LANGUAGES C ASM
+    VERSION 0.0.1
+)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# CPU flags are PER-TARGET (bootloader: hard float; netcore: soft float),
+# set inside each subdir's CMakeLists.txt. Common compile/link options
+# below apply to both.
+
+set(COMMON_FLAGS
+    -ffunction-sections
+    -fdata-sections
+    -Wall
+    -Wextra
+    -Wno-missing-attributes
+    -O0
+    -g3
+)
+
+add_compile_options(${COMMON_FLAGS})
+add_link_options(
+    -Wl,--gc-sections
+    -Wl,--print-memory-usage
+    --specs=nosys.specs
+    -nostartfiles
+)
+
+# ── Nordic MDK + ARM CMSIS-Core via FetchContent ─────────────────────
+include(FetchContent)
+
+FetchContent_Declare(nrfx
+    GIT_REPOSITORY https://github.com/NordicSemiconductor/nrfx.git
+    GIT_TAG        v3.5.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_Declare(cmsis_core
+    GIT_REPOSITORY https://github.com/ARM-software/CMSIS_5.git
+    GIT_TAG        5.9.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(nrfx cmsis_core)
+
+set(NRFX_MDK_INCLUDE   ${nrfx_SOURCE_DIR}/mdk                       CACHE INTERNAL "Nordic MDK headers")
+set(CMSIS_CORE_INCLUDE ${cmsis_core_SOURCE_DIR}/CMSIS/Core/Include  CACHE INTERNAL "ARM CMSIS-Core headers")
+
+# ── dotbot-libs ──────────────────────────────────────────────────────
+set(DOTBOT_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/dotbot-libs"
+    CACHE PATH "Path to dotbot-libs. Defaults to the bundled submodule.")
+
+if(NOT EXISTS "${DOTBOT_LIBS}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "DOTBOT_LIBS=${DOTBOT_LIBS} has no CMakeLists.txt. "
+        "Either initialize the bundled submodule "
+        "(git submodule update --init --recursive) or override "
+        "-DDOTBOT_LIBS=/path/to/your/DotBot-libs checkout.")
+endif()
+
+add_subdirectory(${DOTBOT_LIBS} dotbot-libs-build EXCLUDE_FROM_ALL)
+
+# ── mari ─────────────────────────────────────────────────────────────
+set(MARI "${CMAKE_CURRENT_SOURCE_DIR}/mari"
+    CACHE PATH "Path to mari. Defaults to the bundled submodule.")
+
+if(NOT EXISTS "${MARI}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "MARI=${MARI} has no CMakeLists.txt. "
+        "Either initialize the bundled submodule "
+        "(git submodule update --init --recursive) or override "
+        "-DMARI=/path/to/your/mari checkout.")
+endif()
+
+add_subdirectory(${MARI} mari-build EXCLUDE_FROM_ALL)
+
+# ── Device targets ───────────────────────────────────────────────────
+
+add_subdirectory(device/bootloader)
+add_subdirectory(device/network_core)

--- a/cmake/arm-none-eabi.cmake
+++ b/cmake/arm-none-eabi.cmake
@@ -1,0 +1,20 @@
+# gcc-arm-none-eabi toolchain file for DotBot-firmware CMake builds.
+#
+# Usage:
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake -G Ninja
+
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Pre-empt CMake's compiler check, which would try to link a host binary.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Toolchain executables. Override on the command line with
+#   -DARM_TOOLCHAIN_PREFIX=/path/to/bin/arm-none-eabi-
+# if Homebrew / your installer puts them somewhere CMake can't find.
+set(ARM_TOOLCHAIN_PREFIX "arm-none-eabi-" CACHE STRING "Toolchain command prefix")
+set(CMAKE_C_COMPILER   ${ARM_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_ASM_COMPILER ${ARM_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_CXX_COMPILER ${ARM_TOOLCHAIN_PREFIX}g++)
+set(CMAKE_OBJCOPY      ${ARM_TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "")
+set(CMAKE_SIZE         ${ARM_TOOLCHAIN_PREFIX}size    CACHE INTERNAL "")

--- a/cmake/targets/nrf5340-app-secure/nrf5340_bootloader.ld
+++ b/cmake/targets/nrf5340-app-secure/nrf5340_bootloader.ld
@@ -1,0 +1,191 @@
+/*
+ * GNU ld linker script for the swarmit secure bootloader on
+ * nRF5340 app core. Translates SES MemoryMap.xml + flash_placement.xml
+ * for the bootloader-app target.
+ *
+ * Memory layout:
+ *   FLASH1   0x00000000   65280 B   ← bootloader code (≈63.75 KiB)
+ *   NSC_FLASH 0x0000FF00   256 B    ← NSC veneer (gnu.sgstubs section)
+ *   RAM1     0x20000000    32 KiB   ← bootloader RAM (secure side)
+ *   RAM2     0x20040000   255 KiB   ← available to secure side (unused)
+ *
+ * The .gnu.sgstubs section at 0x0000FF00 is where gcc-arm-none-eabi
+ * places the cmse_nonsecure_entry veneers. NS apps call into this
+ * region; addresses must remain stable across bootloader rebuilds so
+ * existing NS apps don't need re-linking.
+ *
+ * Pinned: .shared_data at 0x20004000 (IPC region — same as elsewhere).
+ */
+
+MEMORY
+{
+    FLASH      (rx)  : ORIGIN = 0x00000000, LENGTH = 0xFF00     /* 65280 B */
+    NSC_FLASH  (rx)  : ORIGIN = 0x0000FF00, LENGTH = 256
+    RAM        (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+}
+
+ENTRY(Reset_Handler)
+
+__STACKSIZE__         = 8K;
+__STACKSIZE_PROCESS__ = 0;
+__HEAPSIZE__          = 0;
+
+__shared_data_addr__  = 0x20004000;
+
+SECTIONS
+{
+    /* ── FLASH ─────────────────────────────────────────────────── */
+
+    .vectors :
+    {
+        KEEP(*(.vectors))
+        KEEP(*(.isr_vector))
+    } > FLASH
+
+    .text :
+    {
+        __text_start__ = .;
+        *(.text*)
+        *(.init)
+        *(.init_rodata)
+        . = ALIGN(4);
+        __text_end__ = .;
+    } > FLASH
+    __text_load_start__ = LOADADDR(.text);
+
+    .rodata :
+    {
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+
+    /* gcc-arm-none-eabi places cmse_nonsecure_entry veneers here. */
+    .gnu.sgstubs :
+    {
+        __sg_start__ = .;
+        *(.gnu.sgstubs*)
+        __sg_end__ = .;
+    } > NSC_FLASH
+
+    /* ── Initialized data: copied flash → RAM by Reset_Handler ──── */
+
+    .data :
+    {
+        . = ALIGN(4);
+        __data_start__ = .;
+        *(.data*)
+        *(.data_run)
+        . = ALIGN(4);
+        __data_end__ = .;
+    } > RAM AT > FLASH
+    __data_load_start__ = LOADADDR(.data);
+
+    .fast :
+    {
+        . = ALIGN(4);
+        __fast_start__ = .;
+        *(.fast*)
+        *(.fast_run)
+        . = ALIGN(4);
+        __fast_end__ = .;
+    } > RAM AT > FLASH
+    __fast_load_start__ = LOADADDR(.fast);
+
+    .ctors :
+    {
+        . = ALIGN(4);
+        __ctors_start__ = .;
+        KEEP(*(SORT(.ctors.*)))
+        KEEP(*(.ctors))
+        __ctors_end__ = .;
+    } > RAM AT > FLASH
+    __ctors_load_start__ = LOADADDR(.ctors);
+
+    .dtors :
+    {
+        . = ALIGN(4);
+        __dtors_start__ = .;
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+        __dtors_end__ = .;
+    } > RAM AT > FLASH
+    __dtors_load_start__ = LOADADDR(.dtors);
+
+    __rodata_start__       = .;
+    __rodata_end__         = .;
+    __rodata_load_start__  = .;
+
+    .tdata :
+    {
+        . = ALIGN(4);
+        __tdata_start__ = .;
+        *(.tdata*)
+        *(.tdata_run)
+        . = ALIGN(4);
+        __tdata_end__ = .;
+    } > RAM AT > FLASH
+    __tdata_load_start__ = LOADADDR(.tdata);
+
+    /* ── Uninitialized data ────────────────────────────────────── */
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .tbss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __tbss_start__ = .;
+        *(.tbss*)
+        __tbss_end__ = .;
+    } > RAM
+
+    .shared_data __shared_data_addr__ (NOLOAD) :
+    {
+        __shared_data_start__ = .;
+        KEEP(*(.shared_data))
+        . = ALIGN(4);
+        __shared_data_end__ = .;
+    } > RAM
+
+    /* ── Heap (empty) ─────────────────────────────────────────── */
+
+    .heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __heap_start__ = .;
+        . = . + __HEAPSIZE__;
+        __heap_end__ = .;
+    } > RAM
+
+    PROVIDE(end  = __heap_start__);
+    PROVIDE(_end = __heap_start__);
+
+    .stack_process (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_process_start__ = .;
+        . = . + __STACKSIZE_PROCESS__;
+        __stack_process_end__ = .;
+    } > RAM
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __STACKSIZE__ (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_start__ = .;
+        . = . + __STACKSIZE__;
+        __stack_end__ = .;
+    } > RAM
+
+    /DISCARD/ :
+    {
+        *(.ARM.exidx*)
+        *(.ARM.extab*)
+    }
+}

--- a/cmake/targets/nrf5340-net/nrf5340_netcore.ld
+++ b/cmake/targets/nrf5340-net/nrf5340_netcore.ld
@@ -1,0 +1,160 @@
+/*
+ * GNU ld linker script for the swarmit netcore firmware on
+ * nRF5340 net core (Cortex-M33 SOFT FLOAT — no FPU).
+ *
+ * Translates SES MemoryMap.xml for the netcore-app target.
+ *
+ * Memory layout:
+ *   FLASH1   0x01000000   254 KiB   ← netcore flash (2 KiB reserved at end)
+ *   RAM1     0x21000000    64 KiB   ← netcore-dedicated RAM
+ *
+ * No NSC region — net core does not have TrustZone partitioning of its
+ * own flash; secure-vs-NS is an app-core concept. Net core gets its
+ * own SPU rules applied from the app-core bootloader.
+ */
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x01000000, LENGTH = 254K
+    RAM   (rwx) : ORIGIN = 0x21000000, LENGTH = 64K
+}
+
+ENTRY(Reset_Handler)
+
+__STACKSIZE__         = 8K;
+__STACKSIZE_PROCESS__ = 0;
+__HEAPSIZE__          = 0;
+
+SECTIONS
+{
+    .vectors :
+    {
+        KEEP(*(.vectors))
+        KEEP(*(.isr_vector))
+    } > FLASH
+
+    .text :
+    {
+        __text_start__ = .;
+        *(.text*)
+        *(.init)
+        *(.init_rodata)
+        . = ALIGN(4);
+        __text_end__ = .;
+    } > FLASH
+    __text_load_start__ = LOADADDR(.text);
+
+    .rodata :
+    {
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+
+    .data :
+    {
+        . = ALIGN(4);
+        __data_start__ = .;
+        *(.data*)
+        *(.data_run)
+        . = ALIGN(4);
+        __data_end__ = .;
+    } > RAM AT > FLASH
+    __data_load_start__ = LOADADDR(.data);
+
+    .fast :
+    {
+        . = ALIGN(4);
+        __fast_start__ = .;
+        *(.fast*)
+        *(.fast_run)
+        . = ALIGN(4);
+        __fast_end__ = .;
+    } > RAM AT > FLASH
+    __fast_load_start__ = LOADADDR(.fast);
+
+    .ctors :
+    {
+        . = ALIGN(4);
+        __ctors_start__ = .;
+        KEEP(*(SORT(.ctors.*)))
+        KEEP(*(.ctors))
+        __ctors_end__ = .;
+    } > RAM AT > FLASH
+    __ctors_load_start__ = LOADADDR(.ctors);
+
+    .dtors :
+    {
+        . = ALIGN(4);
+        __dtors_start__ = .;
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+        __dtors_end__ = .;
+    } > RAM AT > FLASH
+    __dtors_load_start__ = LOADADDR(.dtors);
+
+    __rodata_start__       = .;
+    __rodata_end__         = .;
+    __rodata_load_start__  = .;
+
+    .tdata :
+    {
+        . = ALIGN(4);
+        __tdata_start__ = .;
+        *(.tdata*)
+        *(.tdata_run)
+        . = ALIGN(4);
+        __tdata_end__ = .;
+    } > RAM AT > FLASH
+    __tdata_load_start__ = LOADADDR(.tdata);
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .tbss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __tbss_start__ = .;
+        *(.tbss*)
+        __tbss_end__ = .;
+    } > RAM
+
+    .heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __heap_start__ = .;
+        . = . + __HEAPSIZE__;
+        __heap_end__ = .;
+    } > RAM
+
+    PROVIDE(end  = __heap_start__);
+    PROVIDE(_end = __heap_start__);
+
+    .stack_process (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_process_start__ = .;
+        . = . + __STACKSIZE_PROCESS__;
+        __stack_process_end__ = .;
+    } > RAM
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __STACKSIZE__ (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_start__ = .;
+        . = . + __STACKSIZE__;
+        __stack_end__ = .;
+    } > RAM
+
+    /DISCARD/ :
+    {
+        *(.ARM.exidx*)
+        *(.ARM.extab*)
+    }
+}

--- a/device/bootloader/CMakeLists.txt
+++ b/device/bootloader/CMakeLists.txt
@@ -69,8 +69,7 @@ target_compile_options(bootloader PRIVATE ${BL_CPU_FLAGS} -Os)
 target_include_directories(bootloader PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Source
     ${CMAKE_CURRENT_SOURCE_DIR}/System
-    ${NRFX_MDK_INCLUDE}
-    ${CMSIS_CORE_INCLUDE}
+    # Nordic MDK + ARM CMSIS-Core come via dotbot_nordic (linked below).
     ${DOTBOT_LIBS}/bsp
     ${DOTBOT_LIBS}/bsp/conf
     ${DOTBOT_LIBS}/drv
@@ -90,6 +89,7 @@ target_compile_definitions(bootloader PRIVATE
 )
 
 target_link_libraries(bootloader PRIVATE
+    dotbot_nordic   # headers-only INTERFACE: nrf.h + core_cm33.h
     m
 )
 

--- a/device/bootloader/CMakeLists.txt
+++ b/device/bootloader/CMakeLists.txt
@@ -1,0 +1,115 @@
+# bootloader — the swarmit secure-side bootloader. Runs on nRF5340 app
+# core in TrustZone secure state, owns the SPU/SAU partitioning, and
+# exposes 13 NSC entries (cmse_implib.c) that NS user apps call into.
+#
+# Build outputs:
+#   bootloader.elf / .hex / .bin     ← flashable image
+#   cmse_implib.a                    ← NSC import library, consumed by
+#                                      dotbot-swarmit NS apps
+#
+# Known size constraint (gcc-arm-none-eabi vs armclang/SES):
+#   The bootloader partition is 64 KiB (with 256 B reserved for the NSC
+#   veneer region). The SES Release build fits because armclang produces
+#   tighter .rodata for the lh2_decoder lookup tables. gcc-arm-none-eabi
+#   even at -Os overflows by ~5 KiB. The final link emits cmse_implib.a
+#   correctly (it happens before the FLASH-fit check, so NS apps still
+#   get a valid import library), but the bootloader.elf does not fit.
+#   Follow-up: either enable -flto, or prune unused decoder tables, or
+#   move lh2 entirely to the net core. Out of scope for the CMake
+#   migration — the build path is correct; the binary just exceeds the
+#   partition budget under the GNU toolchain.
+
+set(BL_LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/cmake/targets/nrf5340-app-secure/nrf5340_bootloader.ld)
+
+# Cortex-M33 + TrustZone secure (hard float).
+set(BL_CPU_FLAGS
+    -mcpu=cortex-m33
+    -mthumb
+    -mfloat-abi=hard
+    -mfpu=fpv5-sp-d16
+    -mcmse                        # enable __attribute__((cmse_nonsecure_entry))
+)
+
+add_executable(bootloader
+    Source/main.c
+    Source/battery.c
+    Source/cmse_implib.c
+    Source/ipc.c
+    Source/localization.c
+    Source/mari.c
+    Source/nvmc.c
+    Source/protocol.c
+    Source/rng.c
+    Source/tz.c
+    System/startup.c
+    System/system_init.c
+    System/clock.c
+    System/fault_handlers.c
+
+    # dotbot-libs sources (listed individually — we DO NOT link the
+    # dotbot_libs INTERFACE here because that target ships its own
+    # pure-C startup at nRF/System/cpu.c, which would conflict with
+    # the bootloader's System/startup.c).
+    ${DOTBOT_LIBS}/bsp/nrf/board.c
+    ${DOTBOT_LIBS}/bsp/nrf/gpio.c
+    ${DOTBOT_LIBS}/bsp/nrf/timer.c
+    ${DOTBOT_LIBS}/bsp/nrf/timer_hf.c
+    ${DOTBOT_LIBS}/bsp/nrf/lh2.c
+    ${DOTBOT_LIBS}/bsp/nrf/lh2_decoder.c
+    ${DOTBOT_LIBS}/bsp/nrf/uart.c
+    ${DOTBOT_LIBS}/bsp/nrf/saadc.c     # battery.c / cmse_implib.c call db_saadc_*
+)
+
+# Per-target CPU flags. Also override -O0 → -Os because the bootloader
+# partition is only 64 KiB (less 256 B NSC region). With debug-build
+# -O0 -g3 the .rodata section overflows; SES Release builds with -Os
+# for the same reason.
+target_compile_options(bootloader PRIVATE ${BL_CPU_FLAGS} -Os)
+
+target_include_directories(bootloader PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source
+    ${CMAKE_CURRENT_SOURCE_DIR}/System
+    ${NRFX_MDK_INCLUDE}
+    ${CMSIS_CORE_INCLUDE}
+    ${DOTBOT_LIBS}/bsp
+    ${DOTBOT_LIBS}/bsp/conf
+    ${DOTBOT_LIBS}/drv
+    ${DOTBOT_LIBS}/crypto   # sha256.h is at crypto/sha256.h, not crypto/sha256/
+)
+
+target_compile_definitions(bootloader PRIVATE
+    NRF5340_XXAA
+    NRF_APPLICATION
+    __NRF_FAMILY
+    ARM_MATH_ARMV8MML
+    CONFIG_NFCT_PINS_AS_GPIOS
+    BOARD_NRF5340DK
+    USE_LH2
+    USE_SWARMIT
+    FLASH_PLACEMENT=1
+)
+
+target_link_libraries(bootloader PRIVATE
+    m
+)
+
+target_link_options(bootloader PRIVATE
+    ${BL_CPU_FLAGS}
+    -T${BL_LINKER_SCRIPT}
+    -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/bootloader.map
+    # Emit the NSC import library that NS apps will link against.
+    -Wl,--cmse-implib
+    -Wl,--out-implib=${CMAKE_CURRENT_BINARY_DIR}/cmse_implib.a
+)
+
+set_target_properties(bootloader PROPERTIES LINK_DEPENDS ${BL_LINKER_SCRIPT})
+
+add_custom_command(TARGET bootloader POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O ihex   $<TARGET_FILE:bootloader> ${CMAKE_CURRENT_BINARY_DIR}/bootloader.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:bootloader> ${CMAKE_CURRENT_BINARY_DIR}/bootloader.bin
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:bootloader>
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/bootloader.hex
+               ${CMAKE_CURRENT_BINARY_DIR}/bootloader.bin
+               ${CMAKE_CURRENT_BINARY_DIR}/cmse_implib.a
+    COMMENT "bootloader: hex + bin (+ cmse_implib.a)"
+)

--- a/device/network_core/CMakeLists.txt
+++ b/device/network_core/CMakeLists.txt
@@ -35,8 +35,7 @@ target_compile_options(netcore PRIVATE ${NET_CPU_FLAGS})
 target_include_directories(netcore PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Source
     ${CMAKE_CURRENT_SOURCE_DIR}/System
-    ${NRFX_MDK_INCLUDE}
-    ${CMSIS_CORE_INCLUDE}
+    # Nordic MDK + ARM CMSIS-Core come via dotbot_nordic (linked below).
     ${DOTBOT_LIBS}/bsp
     ${DOTBOT_LIBS}/bsp/conf
     ${DOTBOT_LIBS}/drv
@@ -54,6 +53,7 @@ target_compile_definitions(netcore PRIVATE
 )
 
 target_link_libraries(netcore PRIVATE
+    dotbot_nordic   # headers-only INTERFACE: nrf.h + core_cm33.h
     mari_libs
 )
 

--- a/device/network_core/CMakeLists.txt
+++ b/device/network_core/CMakeLists.txt
@@ -1,0 +1,74 @@
+# netcore — the swarmit network-core firmware. Runs on nRF5340 net core
+# (Cortex-M33 SOFT FLOAT, no FPU). Owns the radio (via mari) and the RNG;
+# exchanges messages with the secure bootloader via IPC.
+
+set(NET_LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/cmake/targets/nrf5340-net/nrf5340_netcore.ld)
+
+# Cortex-M33 net core: no FPU, soft float, NO DSP extension.
+# (gcc-arm-none-eabi defaults cortex-m33 to having DSP; explicitly opt out
+# with +nodsp so core_cm33.h doesn't trip its __DSP_PRESENT guard.)
+set(NET_CPU_FLAGS
+    -mcpu=cortex-m33+nodsp
+    -mthumb
+    -mfloat-abi=soft
+)
+
+add_executable(netcore
+    Source/main.c
+    Source/nvmc.c
+    Source/protocol.c
+    System/startup.c
+    System/system_init.c
+    System/fault_handlers.c
+
+    # dotbot-libs sources (listed individually — netcore has its own
+    # startup at System/startup.c, so we DO NOT link dotbot_libs
+    # INTERFACE here; that would pull in the app-core cpu.c and a
+    # board.c that requires a BOARD_* define net core doesn't need).
+    ${DOTBOT_LIBS}/bsp/nrf/rng.c
+    ${DOTBOT_LIBS}/crypto/sha256.c
+    ${DOTBOT_LIBS}/crypto/soft_sha256.c   # sha256_init/update/final implementations
+)
+
+target_compile_options(netcore PRIVATE ${NET_CPU_FLAGS})
+
+target_include_directories(netcore PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source
+    ${CMAKE_CURRENT_SOURCE_DIR}/System
+    ${NRFX_MDK_INCLUDE}
+    ${CMSIS_CORE_INCLUDE}
+    ${DOTBOT_LIBS}/bsp
+    ${DOTBOT_LIBS}/bsp/conf
+    ${DOTBOT_LIBS}/drv
+    ${DOTBOT_LIBS}/crypto    # sha256.h is at crypto/sha256.h, not crypto/sha256/
+)
+
+target_compile_definitions(netcore PRIVATE
+    NRF5340_XXAA
+    NRF_NETWORK
+    __NO_FPU_ENABLE
+    # ARM_MATH_ARMV8MML omitted — net core has no DSP extension and
+    # gcc-arm-none-eabi rejects core_cm33.h with that define under -mcpu=cortex-m33.
+    USE_LH2
+    FLASH_PLACEMENT=1
+)
+
+target_link_libraries(netcore PRIVATE
+    mari_libs
+)
+
+target_link_options(netcore PRIVATE
+    ${NET_CPU_FLAGS}
+    -T${NET_LINKER_SCRIPT}
+    -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/netcore.map
+)
+
+set_target_properties(netcore PROPERTIES LINK_DEPENDS ${NET_LINKER_SCRIPT})
+
+add_custom_command(TARGET netcore POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O ihex   $<TARGET_FILE:netcore> ${CMAKE_CURRENT_BINARY_DIR}/netcore.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:netcore> ${CMAKE_CURRENT_BINARY_DIR}/netcore.bin
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:netcore>
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/netcore.hex ${CMAKE_CURRENT_BINARY_DIR}/netcore.bin
+    COMMENT "netcore: hex + bin"
+)


### PR DESCRIPTION
Netcore links cleanly under gcc-arm-none-eabi. Bootloader sources all compile and cmse_implib.a is emitted (716 B, same size as the SES-built reference); the final ELF link for the moment fails only on the 64 KiB flash-partition fit (armclang/SES Release packs .rodata tighter than gcc -Os manages here). Optimization to fit the GNU build is tracked separately — the CMake build path itself is correct.