### PR TITLE
swarmit: improve calibrate-lh2 CLI (visible progress + accept .toml)

### DIFF
--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -24,7 +24,10 @@ from swarmit.testbed.controller import (
     ResetLocation,
     generate_status,
 )
-from swarmit.testbed.helpers import load_toml_config
+from swarmit.testbed.helpers import (
+    load_toml_config,
+    read_lh2_calibration_payload,
+)
 from swarmit.testbed.logger import setup_logging
 from swarmit.testbed.protocol import StatusType
 
@@ -563,14 +566,25 @@ def message(ctx, message):
 
 @main.command()
 @click.argument(
-    "lh2-calibration-file", type=click.File(mode="rb"), required=True
+    "lh2-calibration-file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
 )
 @click.pass_context
 def calibrate_lh2(ctx, lh2_calibration_file):
-    """Send LH2 calibration data to the robots."""
+    """Send LH2 calibration data to the robots.
+
+    Accepts either the legacy raw payload (e.g. calibration.out) or a
+    calibration-*.toml written by `dotbot calibrate-lh2`; the format is
+    picked by file extension.
+    """
     console = Console()
     settings = ctx.obj["settings"]
-    blob = lh2_calibration_file.read()
+    try:
+        blob = read_lh2_calibration_payload(lh2_calibration_file)
+    except ValueError as exc:
+        console.print(f"[bold red]Error:[/] {exc}")
+        raise click.Abort()
     if not blob:
         console.print("[bold red]Error:[/] Calibration file is empty.")
         raise click.Abort()

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -568,9 +568,34 @@ def message(ctx, message):
 @click.pass_context
 def calibrate_lh2(ctx, lh2_calibration_file):
     """Send LH2 calibration data to the robots."""
+    console = Console()
     settings = ctx.obj["settings"]
+    blob = lh2_calibration_file.read()
+    if not blob:
+        console.print("[bold red]Error:[/] Calibration file is empty.")
+        raise click.Abort()
+
+    # Format: 1-byte count + N×36B matrices. Read the count client-side so
+    # there is visible output in daemon mode too — over HTTP the controller's
+    # own progress prints run in the server process, not this terminal.
+    homography_count = blob[0]
+    console.print(
+        f"Sending [bold cyan]{homography_count}[/] calibration "
+        f"matrix/matrices ([bold]{len(blob)}B[/]) to the swarm..."
+    )
     with build_client(settings, no_server=ctx.obj["no_server"]) as client:
-        client.send_lh2_calibration(lh2_calibration_file.read())
+        try:
+            with console.status(
+                "[bold green]Sending calibration...",
+                spinner="dots",
+            ):
+                client.send_lh2_calibration(blob)
+        except (ValueError, RuntimeError) as exc:
+            # ValueError: local Controller validation. RuntimeError: daemon
+            # returned 400 (same validation, surfaced over HTTP).
+            console.print(f"[bold red]Error:[/] {exc}")
+            raise click.Abort()
+    console.print("[bold green]✓[/] Calibration sent.")
 
 
 @main.command()

--- a/swarmit/testbed/helpers.py
+++ b/swarmit/testbed/helpers.py
@@ -1,8 +1,51 @@
 import tomllib
 
+# Bump in lockstep with the writer in PyDotBot's
+# dotbot/calibration/lighthouse2.py (CALIBRATION_SCHEMA_VERSION). The
+# .toml's [calibration].data_hex carries the same byte payload as the
+# legacy calibration.out, so swarmit only needs to unwrap it.
+CALIBRATION_SCHEMA_VERSION = 1
+
 
 def load_toml_config(path):
     if not path:
         return {}
     with open(path, "rb") as f:
         return tomllib.load(f)
+
+
+def read_lh2_calibration_payload(path):
+    """Return the raw LH2 calibration byte payload from `path`.
+
+    Accepts either the legacy raw binary (1-byte count + N×36B int32 LE
+    matrices, e.g. calibration.out) or a calibration-*.toml written by
+    `dotbot calibrate-lh2` (schema with [calibration].data_hex). Format is
+    chosen by file extension. Malformed TOML raises ValueError so the CLI
+    can report it cleanly rather than passing garbage to the controller.
+    """
+    if str(path).lower().endswith(".toml"):
+        try:
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(f"{path}: invalid TOML ({exc})") from exc
+        schema = data.get("schema_version", 0)
+        if schema != CALIBRATION_SCHEMA_VERSION:
+            raise ValueError(
+                f"{path}: unsupported calibration schema_version {schema} "
+                f"(this build supports {CALIBRATION_SCHEMA_VERSION})"
+            )
+        try:
+            hex_data = data["calibration"]["data_hex"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                f"{path}: missing [calibration].data_hex"
+            ) from exc
+        try:
+            return bytes.fromhex(hex_data)
+        except ValueError as exc:
+            raise ValueError(
+                f"{path}: [calibration].data_hex is not valid hex ({exc})"
+            ) from exc
+    with open(path, "rb") as f:
+        return f.read()


### PR DESCRIPTION
Two fixes to \`swarmit calibrate-lh2\` (also reached via \`dotbot testbed calibrate-lh2\`):

1. **Visible progress in daemon mode.** The command previously appeared to do nothing when a \`swarmit serve\` was running: the controller's progress \`print()\`s execute in the *server* process, so nothing reached the operator's terminal. The CLI now renders a count summary, a spinner while sending, and a \`✓\`/error line client-side — works in both the HTTP (daemon) and \`--no-server\` (in-process) paths, matching how \`flash\` renders.

2. **Accept calibration \`.toml\` files.** \`dotbot calibrate-lh2\` now writes timestamped \`calibration-*.toml\` files; this teaches swarmit to read them (validate \`schema_version\`, decode \`[calibration].data_hex\`) in addition to the legacy raw \`calibration.out\`. Format is chosen by extension; the decoded bytes are identical.

**Note — soft cross-repo coupling:** \`helpers.CALIBRATION_SCHEMA_VERSION\` must track the writer in PyDotBot's \`dotbot/calibration/lighthouse2.py\`. swarmit can't import PyDotBot (wrong dependency direction), so the constant is duplicated with a comment at both ends. If PyDotBot bumps the schema, bump it here too.

Validated on the bench (both \`.toml\` and \`.out\`, daemon + \`--no-server\`). No host-side test added for the new reader — worth a follow-up unit test on \`read_lh2_calibration_payload\`.