### PR TITLE
swarmit: adopt mari_tx_config_t and label outbound traffic

### DIFF
--- a/device/bootloader-single-core/Source/main.c
+++ b/device/bootloader-single-core/Source/main.c
@@ -104,6 +104,12 @@ typedef struct {
 
 static const gpio_t _status_led = { .port = 1, .pin = 5 };  // TODO: use board specific values
 
+// Mari TX configs used by this bootloader. MARI_TX_INTERNAL is exported
+// from models.h for mari's own metrics-probe sends.
+static const mari_tx_config_t SWARMIT_TX_DEFAULT = {
+    .next_proto = MARI_NEXT_PROTO_SWARMIT_TESTBED,
+};
+
 static bootloader_app_data_t _bootloader_vars = { 0 };
 static swarmit_data_t _swarmit_vars = { 0 };
 extern schedule_t schedule_minuscule, schedule_tiny, schedule_small, schedule_huge, schedule_only_beacons, schedule_only_beacons_optimized_scan;
@@ -260,7 +266,7 @@ int main(void) {
             position_2d_t position = { 0 };
             memcpy(&_bootloader_vars.notification_buffer[length], (void *)&position, sizeof(position_2d_t));
             length += sizeof(position_2d_t);
-            mari_node_tx_payload(_bootloader_vars.notification_buffer, length);
+            mari_node_tx_payload(_bootloader_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
 
         if (_bootloader_vars.req_received) {
@@ -349,7 +355,7 @@ int main(void) {
             metrics_payload->rssi_at_node         = mr_radio_rssi();
 
             // send metrics probe to gateway
-            mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t));
+            mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t), &MARI_TX_INTERNAL);
         }
 
         if (_bootloader_vars.log_received) {
@@ -362,7 +368,7 @@ int main(void) {
             length += sizeof(uint32_t);
             memcpy(_bootloader_vars.notification_buffer + length, (void *)&_swarmit_vars.log, _swarmit_vars.log.length + 1);
             length += _swarmit_vars.log.length + 1;
-            mari_node_tx_payload(_bootloader_vars.notification_buffer, length);
+            mari_node_tx_payload(_bootloader_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
 
         if (_bootloader_vars.ota_start_request) {
@@ -385,7 +391,7 @@ int main(void) {
             size_t length = 0;
             _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_START_ACK;
             while (!mari_node_is_connected()) {}
-            mari_node_tx_payload(_bootloader_vars.notification_buffer, length);
+            mari_node_tx_payload(_bootloader_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
 
         if (_bootloader_vars.ota_chunk_request) {
@@ -406,7 +412,7 @@ int main(void) {
             length += sizeof(uint32_t);
             _swarmit_vars.ota.last_chunk_acked = _swarmit_vars.ota.chunk_index;
             while (!mari_node_is_connected()) {}
-            mari_node_tx_payload(_bootloader_vars.notification_buffer, length);
+            mari_node_tx_payload(_bootloader_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
 
             // If last chunk, finalize computed hash, set back to ready state
             if (_swarmit_vars.ota.chunk_index == _swarmit_vars.ota.chunk_count - 1) {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -78,6 +78,15 @@ volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_shared_d
 static const mr_gpio_t _debug1 = { .port = 1, .pin = 8 };
 //static const mr_gpio_t _debug2 = { .port = 1, .pin = 10 };
 
+// Mari TX configs. MARI_TX_INTERNAL is exported from models.h for mari's
+// own metrics-probe sends.
+static const mari_tx_config_t SWARMIT_TX_DEFAULT = {
+    .next_proto = MARI_NEXT_PROTO_SWARMIT_TESTBED,
+};
+static const mari_tx_config_t SWARMIT_TX_DOTBOT_FORWARD = {
+    .next_proto = MARI_NEXT_PROTO_DOTBOT_APP,
+};
+
 //=========================== functions =========================================
 
 static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length) {
@@ -256,7 +265,7 @@ int main(void) {
             length += sizeof(uint16_t);
             memcpy(&_app_vars.notification_buffer[length], (void *)&ipc_shared_data.current_position, sizeof(position_2d_t));
             length += sizeof(position_2d_t);
-            mari_node_tx_payload(_app_vars.notification_buffer, length);
+            mari_node_tx_payload(_app_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
 
         if (_app_vars.req_received) {
@@ -408,7 +417,7 @@ int main(void) {
                     break;
                 case IPC_MARI_NODE_TX_REQ:
                     while (!mari_node_is_connected()) {}
-                    mari_node_tx_payload((uint8_t *)ipc_shared_data.tx_pdu.buffer, ipc_shared_data.tx_pdu.length);
+                    mari_node_tx_payload((uint8_t *)ipc_shared_data.tx_pdu.buffer, ipc_shared_data.tx_pdu.length, &SWARMIT_TX_DOTBOT_FORWARD);
                     break;
                 case IPC_RNG_INIT_REQ:
                     db_rng_init();
@@ -439,7 +448,7 @@ int main(void) {
             metrics_payload->rssi_at_node         = mr_radio_rssi();
 
             // send metrics probe to gateway
-            mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t));
+            mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t), &MARI_TX_INTERNAL);
         }
 
         if (_app_vars.ipc_log_received) {
@@ -454,7 +463,7 @@ int main(void) {
             memcpy(_app_vars.notification_buffer + length, (void *)&ipc_shared_data.log, ipc_shared_data.log.length + 1);
             mutex_unlock();
             length += ipc_shared_data.log.length + 1;
-            mari_node_tx_payload(_app_vars.notification_buffer, length);
+            mari_node_tx_payload(_app_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adopts the upper-layer-protocol multiplex field added in [mari#154](https://github.com/DotBots/mari/pull/154) (now merged to mari `develop`). Swarmit firmware labels every outbound frame with the appropriate \`mari_tx_config_t\` so receivers can dispatch by namespace.

## Labels

Each main.c declares the constants for the namespaces it sends:

- Swarmit-protocol notifications (status, OTA chunks, …) → \`SWARMIT_TX_DEFAULT\` (next_proto = SWARMIT_TESTBED).
- Mari metrics probes (\`mr_metrics_payload_t\`) → \`MARI_TX_INTERNAL\` (imported from mari's models.h).
- User-app forwarded payloads via \`IPC_MARI_NODE_TX_REQ\` in network_core → \`SWARMIT_TX_DOTBOT_FORWARD\` (next_proto = DOTBOT_APP). Future: extend the IPC PDU so the user app picks next_proto itself.

## Test plan

- [x] CI: all 9 firmware build jobs + 3 Python checks + TypeScript type-check green.
- [ ] Hardware: flash a DotBot v3 + gateway, verify normal join and OTA flow against the updated mari.