### PR TITLE
swarmit/testbed/adapter: dispatch frames by mari next_proto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "rich           >= 14.0.0",
     "structlog      >= 24.4.0",
     "tqdm           >= 4.66.5",
-    "marilib-pkg    >= 0.8.0",
+    "marilib-pkg    >= 0.9.0rc2",
 ]
 description = "Run Your Own Robot Swarm Testbed."
 readme = "README.md"

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -12,6 +12,7 @@ from dotbot_utils.protocol import (
 from marilib.communication_adapter import MQTTAdapter as MarilibMQTTAdapter
 from marilib.communication_adapter import SerialAdapter as MarilibSerialAdapter
 from marilib.mari_protocol import Frame as MariFrame
+from marilib.mari_protocol import NextProto
 from marilib.marilib_cloud import MarilibCloud
 from marilib.marilib_edge import MarilibEdge
 from marilib.model import EdgeEvent, MariNode
@@ -45,6 +46,8 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
             if self.verbose:
                 print("[orange]Node left:[/]", event_data)
         elif event == EdgeEvent.NODE_DATA:
+            if event_data.header.next_proto != NextProto.SWARMIT_TESTBED:
+                return
             try:
                 packet = Packet.from_bytes(event_data.payload)
             except (ValueError, ProtocolPayloadParserException) as exc:
@@ -95,6 +98,7 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
         self.mari.send_frame(
             dst=destination,
             payload=Packet.from_payload(payload).to_bytes(),
+            next_proto=NextProto.SWARMIT_TESTBED,
         )
 
 
@@ -109,6 +113,8 @@ class MarilibCloudAdapter(GatewayAdapterBase):
             if self.verbose:
                 print("[orange]Node left:[/]", event_data)
         elif event == EdgeEvent.NODE_DATA:
+            if event_data.header.next_proto != NextProto.SWARMIT_TESTBED:
+                return
             try:
                 packet = Packet.from_bytes(event_data.payload)
             except (ValueError, ProtocolPayloadParserException) as exc:
@@ -161,4 +167,5 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         self.mari.send_frame(
             dst=destination,
             payload=Packet.from_payload(payload).to_bytes(),
+            next_proto=NextProto.SWARMIT_TESTBED,
         )

--- a/swarmit/tests/test_adapter.py
+++ b/swarmit/tests/test_adapter.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from dotbot_utils.protocol import Packet
 from marilib.mari_protocol import Frame as MariFrame
 from marilib.mari_protocol import Header as MariHeader
+from marilib.mari_protocol import NextProto
 from marilib.model import EdgeEvent
 
 from swarmit.testbed.adapter import MarilibCloudAdapter, MarilibEdgeAdapter
@@ -22,7 +23,10 @@ def test_marilib_edge_adapter(send_frame_mock, _, capsys):
 
     payload = PayloadStatus(device=1, status=2)
     packet = Packet().from_payload(payload)
-    mari_frame = MariFrame(header=MariHeader(), payload=packet.to_bytes())
+    mari_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.SWARMIT_TESTBED),
+        payload=packet.to_bytes(),
+    )
 
     # should ignore if not initialized
     adapter.on_event(EdgeEvent.NODE_DATA, mari_frame)
@@ -36,6 +40,14 @@ def test_marilib_edge_adapter(send_frame_mock, _, capsys):
 
     assert packets == [packet]
 
+    # a frame for another namespace is dropped by the strict next_proto gate
+    other_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.DOTBOT_APP),
+        payload=packet.to_bytes(),
+    )
+    adapter.on_event(EdgeEvent.NODE_DATA, other_frame)
+    assert packets == [packet]
+
     adapter.on_event(EdgeEvent.NODE_JOINED, None)
     out, _ = capsys.readouterr()
     assert "Node joined" in out
@@ -45,14 +57,19 @@ def test_marilib_edge_adapter(send_frame_mock, _, capsys):
     assert "Node left" in out
 
     # invalid frame
-    mari_frame = MariFrame(header=MariHeader(), payload=b"`\x01invalid")
+    mari_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.SWARMIT_TESTBED),
+        payload=b"`\x01invalid",
+    )
     adapter.on_event(EdgeEvent.NODE_DATA, mari_frame)
     out, _ = capsys.readouterr()
     assert "Error parsing packet" in out
 
     adapter.send_payload(mari_frame.header.destination, payload)
     send_frame_mock.assert_called_once_with(
-        dst=mari_frame.header.destination, payload=packet.to_bytes()
+        dst=mari_frame.header.destination,
+        payload=packet.to_bytes(),
+        next_proto=NextProto.SWARMIT_TESTBED,
     )
     adapter.close()
 
@@ -89,7 +106,10 @@ def test_marilib_cloud_adapter(send_frame_mock, _, capsys):
 
     payload = PayloadStatus(device=1, status=2)
     packet = Packet().from_payload(payload)
-    mari_frame = MariFrame(header=MariHeader(), payload=packet.to_bytes())
+    mari_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.SWARMIT_TESTBED),
+        payload=packet.to_bytes(),
+    )
 
     # should ignore if not initialized
     adapter.on_event(EdgeEvent.NODE_DATA, mari_frame)
@@ -103,6 +123,14 @@ def test_marilib_cloud_adapter(send_frame_mock, _, capsys):
 
     assert packets == [packet]
 
+    # a frame for another namespace is dropped by the strict next_proto gate
+    other_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.DOTBOT_APP),
+        payload=packet.to_bytes(),
+    )
+    adapter.on_event(EdgeEvent.NODE_DATA, other_frame)
+    assert packets == [packet]
+
     adapter.on_event(EdgeEvent.NODE_JOINED, None)
     out, _ = capsys.readouterr()
     assert "Node joined" in out
@@ -112,14 +140,19 @@ def test_marilib_cloud_adapter(send_frame_mock, _, capsys):
     assert "Node left" in out
 
     # invalid frame
-    mari_frame = MariFrame(header=MariHeader(), payload=b"`\x01invalid")
+    mari_frame = MariFrame(
+        header=MariHeader(next_proto=NextProto.SWARMIT_TESTBED),
+        payload=b"`\x01invalid",
+    )
     adapter.on_event(EdgeEvent.NODE_DATA, mari_frame)
     out, _ = capsys.readouterr()
     assert "Error parsing packet" in out
 
     adapter.send_payload(mari_frame.header.destination, payload)
     send_frame_mock.assert_called_once_with(
-        dst=mari_frame.header.destination, payload=packet.to_bytes()
+        dst=mari_frame.header.destination,
+        payload=packet.to_bytes(),
+        next_proto=NextProto.SWARMIT_TESTBED,
     )
     adapter.close()
 

--- a/swarmit/tests/utils.py
+++ b/swarmit/tests/utils.py
@@ -5,7 +5,12 @@ import threading
 import time
 
 from dotbot_utils.protocol import Packet
-from marilib.mari_protocol import MARI_BROADCAST_ADDRESS, Frame, Header
+from marilib.mari_protocol import (
+    MARI_BROADCAST_ADDRESS,
+    Frame,
+    Header,
+    NextProto,
+)
 from marilib.model import EdgeEvent, NodeInfoCloud
 from marilib.protocol import PacketType
 
@@ -179,7 +184,10 @@ class SwarmitNode(threading.Thread):
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA)
             + Frame(
                 header=Header(
-                    destination=0, source=self.address, type_=PacketType.DATA
+                    destination=0,
+                    source=self.address,
+                    type_=PacketType.DATA,
+                    next_proto=NextProto.SWARMIT_TESTBED,
                 ),
                 payload=packet.to_bytes(),
             ).to_bytes()


### PR DESCRIPTION
Mari receivers in the testbed decided payload type by sniffing the first payload
byte and trying each namespace in turn. Now that mari's frame header carries an
explicit `next_proto` field (mari#154), the swarmit adapter dispatches on it
directly: it accepts only frames labeled `SWARMIT_TESTBED` and ignores the rest,
and labels its own outbound traffic `SWARMIT_TESTBED` on send. This removes the
cross-namespace guessing and stops swarmit from parsing frames owned by other
protocols.

The gate is strict — frames whose `next_proto` isn't `SWARMIT_TESTBED` are
dropped before parsing. Devices must run firmware that labels `next_proto`
(post-#139) before this is deployed; older firmware sends the unclassified
default and its frames are dropped. Reflash the fleet first.

Depends on `marilib-pkg 0.9.0rc2`, where labeling is the `send_frame(...,
next_proto=...)` keyword argument (mari#155); the pyproject bump is included
here. Validated with tox (tests + cli + check) against the published rc. Hardware-in-the-loop validated.