### PR TITLE
ci: stage mari gateway artifacts before upload

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,14 +67,18 @@ jobs:
       - name: Build mari gateway (app + net) for nrf5340dk
         working-directory: mari/firmware
         run: BUILD_CONFIG=${{ matrix.config }} DOCKER_TARGETS="gateway-app gateway-net" make docker
+      - name: Stage mari gateway artifacts in a flat directory
+        if: matrix.config == 'Debug'
+        run: |
+          mkdir -p stage
+          cp mari/firmware/app/03app_gateway_app/Output/nrf5340-app/${{ matrix.config }}/Exe/03app_gateway_app-nrf5340-app.* stage/
+          cp mari/firmware/app/03app_gateway_net/Output/nrf5340-net/${{ matrix.config }}/Exe/03app_gateway_net-nrf5340-net.* stage/
       - name: Upload artifact
         if: matrix.config == 'Debug'
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-mari-gateway
-          path: |
-            mari/firmware/app/03app_gateway_app/Output/nrf5340-app/${{ matrix.config }}/Exe/03app_gateway_app-nrf5340-app.*
-            mari/firmware/app/03app_gateway_net/Output/nrf5340-net/${{ matrix.config }}/Exe/03app_gateway_net-nrf5340-net.*
+          path: stage/
 
   swarmit-check:
     name: swarmit-check (${{ matrix.os }}, python-${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Fixes a silent gap in the release pipeline introduced in #141. The new `build-mari-gateway` job uploaded `03app_gateway_app-nrf5340-app.*` and `03app_gateway_net-nrf5340-net.*` via a multi-path `upload-artifact@v4` step. That action strips the longest common parent from a multi-path list, so the artifact zip ended up with `03app_gateway_app/Output/.../Exe/...` and `03app_gateway_net/Output/.../Exe/...` as subdirectory trees. `ncipollo/release-action@v1`'s `artifacts: "artifacts/*"` glob then matched the top-level *directories* and emitted:

```
##[warning]Artifact is a directory:artifacts/03app_gateway_net/. Directories can not be uploaded to a release.
##[warning]Artifact is a directory:artifacts/03app_gateway_app/. Directories can not be uploaded to a release.
```

…silently skipping them. As a result `0.8.0rc1`'s release had bootloader + netcore assets but **not** the gateway hex files (those were uploaded manually via `gh release upload` as a one-off backfill).

This adds a staging step that copies both firmware variants' outputs into a single flat `stage/` dir before upload — no more common-parent stripping, no more directory artifacts in the release.

## Test plan

- [x] CI: `build-mari-gateway (Debug)` uploads `artifacts-mari-gateway` containing all 6 files (hex/bin/elf × 2) flat at the artifact root.
- [ ] Next tag push: `release` job's `Release` step shows the four expected gateway-related files in its asset list with no "Artifact is a directory" warnings.
- [ ] `dotbot testbed provision fetch -f <new-tag>` succeeds end-to-end for the gateway case without manual backfill.