### PR TITLE
device/bootloader: harden LH2 calibration path

### DIFF
--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -66,8 +66,10 @@ bool localization_get_position(position_2d_t *position) {
         }
         db_lh2_start();
 
-        if (_localization_data.coordinates[0] < 0 || _localization_data.coordinates[0] > 100000 || _localization_data.coordinates[1] < 0 || _localization_data.coordinates[1] > 100000) {
-            printf("Invalid position (%u,%u)\n", _localization_data.position.x, _localization_data.position.y);
+        double cx = _localization_data.coordinates[0];
+        double cy = _localization_data.coordinates[1];
+        if (!isfinite(cx) || !isfinite(cy) || cx < 0 || cx > 100000 || cy < 0 || cy > 100000) {
+            printf("Invalid position (cx=%f, cy=%f)\n", cx, cy);
             return false;
         }
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -377,7 +377,11 @@ int main(void) {
 
         if (_bootloader_vars.lh2_calibration_ready) {
             _bootloader_vars.lh2_calibration_ready = false;
-            localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+            if (ipc_shared_data.lh2_calibration.homography_count > 0 && ipc_shared_data.lh2_calibration.homography_count <= LH2_BASESTATION_COUNT_MAX) {
+                localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+            } else {
+                printf("Ignoring LH2 calibration update with out-of-range homography count: %u\n", ipc_shared_data.lh2_calibration.homography_count);
+            }
         }
 
         if (_bootloader_vars.ota_start_request) {


### PR DESCRIPTION
## Summary

Two narrow defects in the secure bootloader's LH2 path. Both surface as the user-reported intermittent crash / reset / erratic-motor symptoms.

- **`homography_count` unbounded on the runtime calibration-update path** (`main.c`). The initial-boot path already gates `localization_init` with `0 < homography_count <= LH2_BASESTATION_COUNT_MAX` (`localization.h` = 16); the runtime branch (driven by a fresh `SWRMT_MSG_LH2_CALIBRATION` arriving from the net core) called it raw. A garbage count drives `db_lh2_store_homography(..., lh_index, ...)` out of bounds inside secure RAM → SecureFault → reset. Mirrors the existing predicate verbatim and logs the rejected count.
- **NaN/Inf sailed past the position range check** (`localization.c`). `coordinates[i] < 0 || coordinates[i] > 100000` is always false for NaN (C semantics), so a degenerate LH2 solve (all-zero homography, divide-by-zero deep in `db_lh2_calculate_position`) reached the `(uint32_t)` cast at the next line — undefined cast, undefined coordinates, motors twitch. Now: `isfinite()` + range, fails closed. The `printf` also now logs the raw doubles (`cx=%f, cy=%f`) instead of the stale prior-iteration `position.x/y` cast.

`bootloader-single-core/` has no LH2 path — no parallel patch needed. No `dotbot-libs` submodule bump.

## Test plan

- [x] dotbot-v3 Release builds (local SES, `make bootloader`)
- [x] nrf5340dk Debug builds (local SES, `make bootloader`)
- [ ] HIL: boot without calibration → "Initializing without LH2 calibration data", no reset.
- [ ] HIL: TOML with `homography_count` outside [1, 16] through `swarmit calibrate-lh2 apply` → "Ignoring LH2 calibration update with out-of-range homography count: N", no reset.
- [ ] HIL: well-formed calibration with all-zero homography matrices → "Invalid position (cx=nan, cy=nan)" on next position update, no reset, motors idle.
- [ ] HIL: real calibration → no behavior change vs unpatched develop.