### PR TITLE
device: harden demo-path crash sources (LH2 bootloader + OTA chunk race + IPC memory barrier)

### DIFF
--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -69,7 +69,10 @@ bool localization_get_position(position_2d_t *position) {
         double cx = _localization_data.coordinates[0];
         double cy = _localization_data.coordinates[1];
         if (!isfinite(cx) || !isfinite(cy) || cx < 0 || cx > 100000 || cy < 0 || cy > 100000) {
-            printf("Invalid position (cx=%f, cy=%f)\n", cx, cy);
+            // No %f here: the bootloader's `linker_printf_fp_enabled=Float`
+            // formatter misbehaves on NaN/Inf, and this branch fires on
+            // exactly those values.
+            puts("Invalid LH2 position (non-finite or out-of-range)");
             return false;
         }
 

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -66,8 +66,10 @@ bool localization_get_position(position_2d_t *position) {
         }
         db_lh2_start();
 
-        if (_localization_data.coordinates[0] < 0 || _localization_data.coordinates[0] > 100000 || _localization_data.coordinates[1] < 0 || _localization_data.coordinates[1] > 100000) {
-            printf("Invalid position (%u,%u)\n", _localization_data.position.x, _localization_data.position.y);
+        double cx = _localization_data.coordinates[0];
+        double cy = _localization_data.coordinates[1];
+        if (!isfinite(cx) || !isfinite(cy) || cx < 0 || cx > 100000 || cy < 0 || cy > 100000) {
+            printf("Invalid position (cx=%f, cy=%f)\n", cx, cy);
             return false;
         }
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -377,7 +377,11 @@ int main(void) {
 
         if (_bootloader_vars.lh2_calibration_ready) {
             _bootloader_vars.lh2_calibration_ready = false;
-            localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+            if (ipc_shared_data.lh2_calibration.homography_count > 0 && ipc_shared_data.lh2_calibration.homography_count <= LH2_BASESTATION_COUNT_MAX) {
+                localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
+            } else {
+                printf("Ignoring LH2 calibration update with out-of-range homography count: %u\n", ipc_shared_data.lh2_calibration.homography_count);
+            }
         }
 
         if (_bootloader_vars.ota_start_request) {

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -409,6 +409,9 @@ int main(void) {
         if (_bootloader_vars.ota_chunk_request) {
             _bootloader_vars.ota_chunk_request = false;
 
+            // Serialize with netcore's OTA chunk writes so that chunk_index, chunk_size,
+            // and the chunk buffer can't be mutated mid-flash by a back-to-back chunk.
+            mutex_lock();
             if (ipc_shared_data.ota.last_chunk_acked != (int32_t)ipc_shared_data.ota.chunk_index) {
                 // Write chunk to flash
                 uint32_t addr = _bootloader_vars.base_addr + ipc_shared_data.ota.chunk_index * SWRMT_OTA_CHUNK_SIZE;
@@ -423,12 +426,14 @@ int main(void) {
             memcpy(_bootloader_vars.notification_buffer + length, (void *)&ipc_shared_data.ota.chunk_index, sizeof(uint32_t));
             length += sizeof(uint32_t);
             ipc_shared_data.ota.last_chunk_acked = ipc_shared_data.ota.chunk_index;
-            mari_node_tx(_bootloader_vars.notification_buffer, length);
 
             // If last chunk, finalize computed hash, set back to ready state
             if (ipc_shared_data.ota.chunk_index == ipc_shared_data.ota.chunk_count - 1) {
                 ipc_shared_data.status = SWRMT_APPLICATION_READY;
             }
+            mutex_unlock();
+
+            mari_node_tx(_bootloader_vars.notification_buffer, length);
         }
 
         if (_bootloader_vars.start_application) {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -436,6 +436,11 @@ int main(void) {
                 default:
                     break;
             }
+            // Ensure prior payload writes (tx_pdu, rng.value, …) are observable
+            // to the app core before it sees the net_ack release-store. On the
+            // dual-M33 nRF5340, volatile alone does not order across the AXI
+            // fabric.
+            __DMB();
             ipc_shared_data.net_ack = true;
             _app_vars.ipc_req      = IPC_REQ_NONE;
         }

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -319,21 +319,29 @@ int main(void) {
                     }
 
                     const swrmt_ota_chunk_pkt_t *pkt = (const swrmt_ota_chunk_pkt_t *)req->data;
-                    ipc_shared_data.ota.chunk_index = pkt->index;
 
-                    // Check chunk index is valid
-                    if (ipc_shared_data.ota.chunk_index >= ipc_shared_data.ota.chunk_count) {
-                        printf("Invalid chunk index %u\n", ipc_shared_data.ota.chunk_index);
+                    // Check chunk index is valid. Compare against pkt directly so
+                    // the bound is unaffected by any concurrent IPC chunk_index write.
+                    if (pkt->index >= ipc_shared_data.ota.chunk_count) {
+                        printf("Invalid chunk index %u\n", pkt->index);
                         break;
                     }
 
-                    // Only check for matching sha if chunk was not already acked
-                    if (ipc_shared_data.ota.last_chunk_acked != (int32_t)ipc_shared_data.ota.chunk_index) {
-                        printf("Verify SHA for chunk %u: ", ipc_shared_data.ota.chunk_index);
-                        ipc_shared_data.ota.chunk_size = pkt->chunk_size;
-                        mutex_lock();
+                    bool need_verify = (ipc_shared_data.ota.last_chunk_acked != (int32_t)pkt->index);
+
+                    // Publish chunk_index + chunk_size + chunk buffer atomically so
+                    // the bootloader sees a consistent (index, size, buffer) view
+                    // even when chunks arrive back-to-back.
+                    mutex_lock();
+                    ipc_shared_data.ota.chunk_index = pkt->index;
+                    ipc_shared_data.ota.chunk_size  = pkt->chunk_size;
+                    if (need_verify) {
                         memcpy((uint8_t *)ipc_shared_data.ota.chunk, pkt->chunk, pkt->chunk_size);
-                        mutex_unlock();
+                    }
+                    mutex_unlock();
+
+                    if (need_verify) {
+                        printf("Verify SHA for chunk %u: ", pkt->index);
 
                         // Copy expected hash
                         memcpy(_app_vars.expected_hash, pkt->sha, SWRMT_OTA_SHA256_LENGTH);
@@ -351,7 +359,7 @@ int main(void) {
                         }
                         puts("OK");
                     }
-                    printf("Process OTA chunk request (index: %u, size: %u)\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_size);
+                    printf("Process OTA chunk request (index: %u, size: %u)\n", pkt->index, pkt->chunk_size);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_CHUNK] = 1;
                 } break;
                 case SWRMT_MSG_LH2_CALIBRATION:


### PR DESCRIPTION
## Summary

Supersedes #143. Five surgical fixes against the crash sources most likely to fire during a live demo (LH2 navigation + remote OTA flashing of the swarm). All bootloader/netcore-side; companion DotBot-firmware PR #411 covers the app-side (waypoint stack-smash + ISR-flag race).

**LH2 path (from #143):**
- **Bound `homography_count` on the runtime calibration-update path.** The initial-boot path already gates this; the runtime branch did not. A bogus count drives `db_lh2_store_homography(..., lh_index, ...)` out of bounds → SecureFault → reset.
- **Reject NaN/Inf positions.** `coordinates[i] < 0 || > 100000` is always false for NaN (C semantics); the `(uint32_t)` cast on NaN is UB. `isfinite()` + range fails closed.

**OTA path (new — for live remote-flash demo):**
- **Bootloader: serialize the OTA chunk handler with netcore via the existing position-path mutex.** A back-to-back chunk could let netcore mutate `chunk_index`/`chunk_size`/`chunk` while the bootloader was mid-flash on the previous one — torn `nvmc_write`.
- **Netcore: publish `chunk_index`, `chunk_size`, and the chunk buffer atomically under one mutex region.** Previously only the buffer memcpy was locked; the bootloader could observe a mismatched (index, size, buffer) triple. The validity check now reads `pkt->index` directly so it's independent of partial IPC state.

**IPC barrier:**
- **`__DMB()` before the `net_ack = true` release-store in netcore.** On the dual-M33 nRF5340 the AXI fabric can reorder prior payload writes (tx_pdu, rng.value, …) past a `volatile` write, so the app core could see `net_ack=true` with stale payload bytes. One instruction, zero regression risk.

## Test plan

- [x] dotbot-v3 Release bootloader builds (local SES).
- [x] nrf5340dk Debug bootloader builds (local SES).
- [x] Release netcore builds (local SES).
- [ ] HIL: boot DotBot v3 without calibration → "Initializing without LH2 calibration data", no reset.
- [ ] HIL: stress runtime calibration with out-of-range `homography_count` (hand-edited TOML through `swarmit calibrate-lh2 apply`) → new log line, no reset.
- [ ] HIL: well-formed calibration with all-zero homography → `Invalid position (cx=nan, cy=nan)`, no reset, motors idle.
- [ ] HIL: `swarmit testbed flash <bin>` against a swarm → progresses cleanly, no torn chunks, ACKs land as expected.
- [ ] HIL: long teleop session post-flash → no observable IPC desync (no stale tx_pdu, no spurious RNG output).