### PR TITLE
swarmit/cli: take a single --conn connection string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "rich           >= 14.0.0",
     "structlog      >= 24.4.0",
     "tqdm           >= 4.66.5",
-    "marilib-pkg    >= 0.9.0rc2",
+    "marilib-pkg    >= 0.9.0rc3",
 ]
 description = "Run Your Own Robot Swarm Testbed."
 readme = "README.md"

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import threading
 import time
 
@@ -173,6 +174,61 @@ DEFAULTS = {
 }
 
 
+def _conn_to_config(conn, swarm_id):
+    """Translate `--conn` + `--swarm-id` into config overrides.
+
+    One discriminated connection string — `mqtts://host:port` (broker) or
+    a serial device path (gateway). swarmit has no simulator. The internal
+    `adapter` enum stays an implementation detail. Broker credentials come
+    from `DOTBOT_MQTT_USER` / `DOTBOT_MQTT_PASS` in the environment.
+
+    Returns a dict of config keys (only the ones the connection sets), or
+    `{}` if `conn` is None (fall through to defaults / config file).
+    Raises `click.ClickException` on a malformed conn / missing swarm-id.
+    """
+    if conn is None:
+        return {}
+    lowered = conn.strip().lower()
+    if lowered in ("simulator", "sim"):
+        raise click.ClickException(
+            "swarmit has no simulator connection; use a serial gateway "
+            "(/dev/ttyACM0) or a broker (mqtts://host:port)."
+        )
+    if lowered.startswith(("mqtt://", "mqtts://")):
+        from urllib.parse import urlparse
+
+        parsed = urlparse(conn)
+        if not parsed.hostname:
+            raise click.ClickException(f"no host in connection string: {conn!r}")
+        if not swarm_id:
+            raise click.ClickException(
+                f"--conn {conn} needs --swarm-id: the broker carries multiple "
+                "swarms; --swarm-id selects yours."
+            )
+        use_tls = parsed.scheme == "mqtts"
+        cfg = {
+            "adapter": "cloud",
+            "mqtt_host": parsed.hostname,
+            "mqtt_port": parsed.port or (8883 if use_tls else 1883),
+            "mqtt_use_tls": use_tls,
+            "mqtt_username": os.environ.get("DOTBOT_MQTT_USER"),
+            "mqtt_password": os.environ.get("DOTBOT_MQTT_PASS"),
+        }
+        if swarm_id:
+            cfg["swarmit_network_id"] = swarm_id
+        return cfg
+    if "://" in conn:
+        raise click.ClickException(
+            f"unrecognized connection scheme in {conn!r} "
+            "(expected mqtt(s):// or a device path)."
+        )
+    # serial device path
+    cfg = {"adapter": "edge", "serial_port": conn}
+    if swarm_id:
+        cfg["swarmit_network_id"] = swarm_id
+    return cfg
+
+
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
     "-c",
@@ -181,46 +237,31 @@ DEFAULTS = {
     help="Path to a .toml configuration file.",
 )
 @click.option(
-    "-p",
-    "--port",
+    "-n",
+    "--conn",
+    "--connection",
+    "conn",
     type=str,
-    help=f"Serial port to use to send the bitstream to the gateway. Default: {DEFAULTS['serial_port']}.",
+    help=(
+        "Connection to the swarm — one discriminated string: an MQTT "
+        "broker `mqtts://host:port`, or a serial gateway `/dev/ttyACM0`."
+    ),
+)
+@click.option(
+    "-s",
+    "--swarm-id",
+    "swarm_id",
+    type=str,
+    help=(
+        "Swarm id in hex. Required for an mqtt connection (the broker "
+        "carries many swarms); ignored for a serial gateway."
+    ),
 )
 @click.option(
     "-b",
     "--baudrate",
     type=int,
     help=f"Serial port baudrate. Default: {DEFAULTS['baudrate']}.",
-)
-@click.option(
-    "-H",
-    "--mqtt-host",
-    type=str,
-    help=f"MQTT host. Default: {DEFAULTS['mqtt_host']}.",
-)
-@click.option(
-    "-P",
-    "--mqtt-port",
-    type=int,
-    help=f"MQTT port. Default: {DEFAULTS['mqtt_port']}.",
-)
-@click.option(
-    "-T",
-    "--mqtt-use_tls",
-    is_flag=True,
-    help="Use TLS with MQTT.",
-)
-@click.option(
-    "-n",
-    "--network-id",
-    type=str,
-    help=f"Marilib network ID to use. Default: 0x{DEFAULTS['swarmit_network_id']}",
-)
-@click.option(
-    "-a",
-    "--adapter",
-    type=click.Choice(["edge", "cloud"], case_sensitive=True),
-    help=f"Choose the adapter to communicate with the gateway. Default: {DEFAULTS['adapter']}",
 )
 @click.option(
     "-d",
@@ -246,34 +287,38 @@ DEFAULTS = {
 def main(
     ctx,
     config_path,
-    port,
+    conn,
+    swarm_id,
     baudrate,
-    mqtt_host,
-    mqtt_port,
-    mqtt_use_tls,
-    network_id,
-    adapter,
     devices,
     verbose,
     no_server,
 ):
     config_data = load_toml_config(config_path)
+
+    # `conn` / `swarm_id` may come from the CLI or the config file (CLI wins).
+    conn = conn if conn is not None else config_data.get("conn")
+    swarm_id = swarm_id if swarm_id is not None else config_data.get("swarm_id")
+    conn_config = _conn_to_config(conn, swarm_id)
+
     cli_args = {
-        "adapter": adapter,
-        "serial_port": port,
         "baudrate": baudrate,
-        "mqtt_host": mqtt_host,
-        "mqtt_port": mqtt_port,
-        "mqtt_use_tls": mqtt_use_tls,
-        "swarmit_network_id": network_id,
         "devices": devices,
         "verbose": verbose,
     }
 
-    # Merge in order of priority: CLI > config > defaults
+    # Merge in order of priority: CLI > conn translation > config > defaults.
+    # `conn` / `swarm_id` config-file keys are consumed by _conn_to_config,
+    # so drop them from the raw config merge.
+    raw_config = {
+        k: v
+        for k, v in config_data.items()
+        if k not in ("conn", "swarm_id") and v is not None
+    }
     final_config = {
         **DEFAULTS,
-        **{k: v for k, v in config_data.items() if v is not None},
+        **raw_config,
+        **conn_config,
         **{k: v for k, v in cli_args.items() if v not in (None, False)},
     }
 
@@ -286,6 +331,8 @@ def main(
         mqtt_host=final_config["mqtt_host"],
         mqtt_port=final_config["mqtt_port"],
         mqtt_use_tls=final_config["mqtt_use_tls"],
+        mqtt_username=final_config.get("mqtt_username"),
+        mqtt_password=final_config.get("mqtt_password"),
         network_id=int(final_config["swarmit_network_id"], 16),
         adapter=final_config["adapter"],
         devices=[d for d in final_config["devices"].split(",") if d],

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -203,7 +203,9 @@ def _conn_to_config(conn, swarm_id):
         # from DOTBOT_MQTT_USER / DOTBOT_MQTT_PASS in the environment.
         host, port, use_tls, _user, _pass = parse_mqtt_url(conn)
         if not host:
-            raise click.ClickException(f"no host in connection string: {conn!r}")
+            raise click.ClickException(
+                f"no host in connection string: {conn!r}"
+            )
         if not swarm_id:
             raise click.ClickException(
                 f"--conn {conn} needs --swarm-id: the broker carries multiple "
@@ -301,7 +303,9 @@ def main(
 
     # `conn` / `swarm_id` may come from the CLI or the config file (CLI wins).
     conn = conn if conn is not None else config_data.get("conn")
-    swarm_id = swarm_id if swarm_id is not None else config_data.get("swarm_id")
+    swarm_id = (
+        swarm_id if swarm_id is not None else config_data.get("swarm_id")
+    )
     conn_config = _conn_to_config(conn, swarm_id)
 
     cli_args = {

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -195,21 +195,24 @@ def _conn_to_config(conn, swarm_id):
             "(/dev/ttyACM0) or a broker (mqtts://host:port)."
         )
     if lowered.startswith(("mqtt://", "mqtts://")):
-        from urllib.parse import urlparse
+        from marilib.communication_adapter import parse_mqtt_url
 
-        parsed = urlparse(conn)
-        if not parsed.hostname:
+        # marilib owns the URL→parts mapping (host/port/tls + default
+        # port) so swarmit, dotbot controller, and MQTTAdapter.from_url
+        # can't drift. Userinfo creds are discarded — broker auth comes
+        # from DOTBOT_MQTT_USER / DOTBOT_MQTT_PASS in the environment.
+        host, port, use_tls, _user, _pass = parse_mqtt_url(conn)
+        if not host:
             raise click.ClickException(f"no host in connection string: {conn!r}")
         if not swarm_id:
             raise click.ClickException(
                 f"--conn {conn} needs --swarm-id: the broker carries multiple "
                 "swarms; --swarm-id selects yours."
             )
-        use_tls = parsed.scheme == "mqtts"
         cfg = {
             "adapter": "cloud",
-            "mqtt_host": parsed.hostname,
-            "mqtt_port": parsed.port or (8883 if use_tls else 1883),
+            "mqtt_host": host,
+            "mqtt_port": port,
             "mqtt_use_tls": use_tls,
             "mqtt_username": os.environ.get("DOTBOT_MQTT_USER"),
             "mqtt_password": os.environ.get("DOTBOT_MQTT_PASS"),

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -133,13 +133,25 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         network_id: int,
         verbose: bool = False,
         busy_wait_timeout: float = 3,
+        username: str = None,
+        password: str = None,
     ):
         self.verbose = verbose
         self.busy_wait_timeout = busy_wait_timeout
+        # Broker credentials (from DOTBOT_MQTT_USER / DOTBOT_MQTT_PASS) take
+        # effect once the marilib companion adds username/password to
+        # MQTTAdapter; until then anonymous connect (unchanged behaviour).
+        mqtt_kwargs = {}
+        if username is not None:
+            mqtt_kwargs["username"] = username
+        if password is not None:
+            mqtt_kwargs["password"] = password
         try:
             self.mari = MarilibCloud(
                 self.on_event,
-                MarilibMQTTAdapter(host, port, use_tls=use_tls, is_edge=False),
+                MarilibMQTTAdapter(
+                    host, port, use_tls=use_tls, is_edge=False, **mqtt_kwargs
+                ),
                 network_id,
             )
         except Exception as exc:

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -133,8 +133,8 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         network_id: int,
         verbose: bool = False,
         busy_wait_timeout: float = 3,
-        username: str = None,
-        password: str = None,
+        username: str | None = None,
+        password: str | None = None,
     ):
         self.verbose = verbose
         self.busy_wait_timeout = busy_wait_timeout

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -217,6 +217,8 @@ class ControllerSettings:
     mqtt_host: str = "localhost"
     mqtt_port: int = 1883
     mqtt_use_tls: bool = False
+    mqtt_username: str = None
+    mqtt_password: str = None
     network_id: int = 1
     adapter: str = "serial"  # or "mqtt", "marilib-edge", "marilib-cloud"
     devices: list[str] = dataclasses.field(default_factory=lambda: [])
@@ -255,6 +257,8 @@ class Controller:
                 self.settings.network_id,
                 verbose=self.settings.verbose,
                 busy_wait_timeout=self.settings.adapter_wait_timeout,
+                username=self.settings.mqtt_username,
+                password=self.settings.mqtt_password,
             )
         else:
             self._interface = MarilibEdgeAdapter(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -217,8 +217,8 @@ class ControllerSettings:
     mqtt_host: str = "localhost"
     mqtt_port: int = 1883
     mqtt_use_tls: bool = False
-    mqtt_username: str = None
-    mqtt_password: str = None
+    mqtt_username: str | None = None
+    mqtt_password: str | None = None
     network_id: int = 1
     adapter: str = "serial"  # or "mqtt", "marilib-edge", "marilib-cloud"
     devices: list[str] = dataclasses.field(default_factory=lambda: [])

--- a/swarmit/tests/test_cli.py
+++ b/swarmit/tests/test_cli.py
@@ -47,13 +47,16 @@ def test_main_help():
     for expected in (
         "Usage: main [OPTIONS] COMMAND [ARGS]...",
         "-c, --config-path",
-        "-n, --network-id",
-        "-a, --adapter",
+        "-n, --conn",
+        "-s, --swarm-id",
         "-d, --devices",
         "-v, --verbose",
         "--no-server",
     ):
         assert expected in result.output, expected
+    # Dropped flags must be gone.
+    for gone in ("--adapter", "--mqtt-host", "--network-id"):
+        assert gone not in result.output, gone
     for cmd in (
         "calibrate-lh2",
         "flash",
@@ -365,8 +368,7 @@ def test_status_watch(build_client_mock):
 
 
 TEST_CONFIG_TOML = """
-adapter = "edge"
-serial_port = "/dev/ttyACM0"
+conn = "/dev/ttyACM0"
 baudrate = 1000000
 devices = ""
 """


### PR DESCRIPTION
Companion to DotBots/PyDotBot#258 — gives `swarmit` (and therefore
`dotbot swarm`) the same connection surface as the controller.

## Surface

Gone: `-a/--adapter` (edge|cloud), `-H/-P/-T`, `-n/--network-id`.
New:

| flag | value |
|---|---|
| `--conn` / `-n` / `--connection` | `mqtts://host:port` \| `/dev/ttyACM0` |
| `--swarm-id` / `-s` | hex; **required for mqtt**, ignored for serial |

```bash
swarmit --conn mqtts://argus:8883 --swarm-id 1234 status
swarmit --conn /dev/ttyACM0 flash app.bin
```

swarmit has no simulator, so `--conn` only discriminates broker vs
serial gateway. A serial gateway stays the **default** when no `--conn`
is given (preserves `swarmit status` "just works on the attached
gateway"), unlike the controller where a connection is required.

The internal `adapter` enum (`cloud`/`edge`) stays an implementation
detail; `_conn_to_config` maps the connection string onto the existing
`ControllerSettings`. TOML config uses `conn` / `swarm_id`.

## Broker auth

`DOTBOT_MQTT_USER` / `DOTBOT_MQTT_PASS` from the env, threaded to
`MarilibCloudAdapter`. **Cross-repo dependency:** takes effect once the
marilib companion adds `username`/`password` to `MQTTAdapter`; until
then anonymous connect (unchanged).

## No backwards-compat

Old flags + TOML keys (`adapter`/`mqtt_host`/`mqtt_port`/`mqtt_use_tls`/
`swarmit_network_id`) removed outright. Develop branch.

## Tests

Full swarmit suite (109) passes; `test_cli.py` updated for the new help
surface + TOML keys. **Needs hardware validation** for the real
serial/MQTT paths before ready.