### PR TITLE
device/network_core: fix OTA flash stalling at 0 chunks

### DIFF
--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -415,10 +415,16 @@ int main(void) {
                         _app_vars.mari_initialized = true;
                     }
                     break;
-                case IPC_MARI_NODE_TX_REQ:
+                case IPC_MARI_NODE_TX_REQ: {
                     while (!mari_node_is_connected()) {}
-                    mari_node_tx_payload((uint8_t *)ipc_shared_data.tx_pdu.buffer, ipc_shared_data.tx_pdu.length, &SWARMIT_TX_DOTBOT_FORWARD);
+                    // forward user-image data as DOTBOT_APP, but keep the bootloader's
+                    // messages when user image is not running
+                    bool user_running = (ipc_shared_data.status == SWRMT_APPLICATION_RUNNING ||
+                                         ipc_shared_data.status == SWRMT_APPLICATION_STOPPING);
+                    const mari_tx_config_t *tx_config = user_running ? &SWARMIT_TX_DOTBOT_FORWARD : &SWARMIT_TX_DEFAULT;
+                    mari_node_tx_payload((uint8_t *)ipc_shared_data.tx_pdu.buffer, ipc_shared_data.tx_pdu.length, tx_config);
                     break;
+                }
                 case IPC_RNG_INIT_REQ:
                     db_rng_init();
                     break;

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -47,6 +47,11 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
                 print("[orange]Node left:[/]", event_data)
         elif event == EdgeEvent.NODE_DATA:
             if event_data.header.next_proto != NextProto.SWARMIT_TESTBED:
+                if self.verbose:
+                    print(
+                        "[red]swarmit: dropping NODE_DATA frame with "
+                        f"unexpected next_proto {event_data.header.next_proto!r}[/]"
+                    )
                 return
             try:
                 packet = Packet.from_bytes(event_data.payload)
@@ -114,6 +119,11 @@ class MarilibCloudAdapter(GatewayAdapterBase):
                 print("[orange]Node left:[/]", event_data)
         elif event == EdgeEvent.NODE_DATA:
             if event_data.header.next_proto != NextProto.SWARMIT_TESTBED:
+                if self.verbose:
+                    print(
+                        "[red]swarmit: dropping NODE_DATA frame with "
+                        f"unexpected next_proto {event_data.header.next_proto!r}[/]"
+                    )
                 return
             try:
                 packet = Packet.from_bytes(event_data.payload)


### PR DESCRIPTION
## Problem

`swarm flash` (and `device`-side OTA) transferred **0 chunks** and left dual-core
bots stuck in Programming — `Flashing 0 bot(s), elapsed 0.000s`. The bot acked
(`0x86` visible on the gateway) and reported STATUS, but the controller never
collected a single acked device. A regression from the next_proto adoption
(#139 + #140).

## Root cause

The net core's `IPC_MARI_NODE_TX_REQ` handler forwarded **all** app-core traffic
as `DOTBOT_APP` (0x11). That one IPC channel is shared by the bootloader's OTA
control acks and the running user image's data. The host adapter's strict gate
admits only `SWARMIT_TESTBED` (0x10), so every OTA ack was silently dropped →
0 acked devices → 0 chunks. STATUS frames survived because the net core emits
them directly with the 0x10 config — which is exactly why status showed but
flashing didn't.

## Fix

Label the forwarded frame by application status: the user image is in control
during `RUNNING`/`STOPPING` → `DOTBOT_APP`; otherwise it's bootloader control →
`SWARMIT_TESTBED`. The net core sets `status = PROGRAMMING` before the OTA-start
ack returns over IPC, so acks are reliably 0x10. `STOPPING` is included so
user-app data sent during the ~1s watchdog grace after a stop isn't mislabeled.

The host adapter also now logs dropped NODE_DATA frames under `--verbose` — the
silent drop is what made this take a deep trace to find.

## Follow-up (not in this PR)

The durable fix is to carry the real next_proto through the IPC PDU so the
bootloader and the NS user image each set their own namespace, instead of the
net core inferring it from status. Status is a correct proxy today but can't
tell a non-DotBot user image apart.

## Validation

HIL on a DotBot v3: netcore reflashed, `swarmit flash` of the spin sandbox app
transferred 38/38 chunks and the bot rebooted into Running. Netcore builds clean
(SES); `test_adapter.py` green.