### PR TITLE
lh2: trigger a raw LH2 count capture over the air

### DIFF
--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -39,6 +39,7 @@ typedef enum {
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
     IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
+    IPC_CHAN_LH2_CAPTURE        = 9,    ///< Channel used to trigger a raw LH2 capture (READY mode only)
 } ipc_channels_t;
 
 typedef struct __attribute__((packed)) {

--- a/device/bootloader/Source/localization.c
+++ b/device/bootloader/Source/localization.c
@@ -18,6 +18,7 @@ typedef struct {
 
 static __attribute__((aligned(4))) localization_data_t _localization_data = { 0 };
 static bool _calibration_loaded = false;
+static bool _lh2_started = false;
 
 float _distance(position_2d_t *reference, position_2d_t *current) {
     float dx = ((float)current->x - (float)reference->x);
@@ -25,10 +26,18 @@ float _distance(position_2d_t *reference, position_2d_t *current) {
     return sqrtf(powf(dx, 2) + powf(dy, 2));
 }
 
-void localization_init(int32_t homographies[][3][3], uint32_t homography_count) {
-    printf("Initialize localization with %u homography matrices\n", homography_count);
+void localization_start(void) {
+    if (_lh2_started) {
+        return;
+    }
     db_lh2_init(&_localization_data.lh2, &db_lh2_d, &db_lh2_e);
     db_lh2_start();
+    _lh2_started = true;
+}
+
+void localization_init(int32_t homographies[][3][3], uint32_t homography_count) {
+    printf("Initialize localization with %u homography matrices\n", homography_count);
+    localization_start();
 
     for (uint8_t lh_index = 0; lh_index < homography_count; lh_index++) {
         printf("Store homography matrix for LH%u:\n", lh_index);
@@ -99,4 +108,21 @@ bool localization_get_position(position_2d_t *position) {
     }
 
     return false;
+}
+
+uint8_t localization_get_raw_counts(lh2_raw_sample_t *out, uint8_t max) {
+    uint8_t n = 0;
+    db_lh2_stop();
+    for (uint8_t lh_index = 0; lh_index < LH2_BASESTATION_COUNT && n < max; lh_index++) {
+        if (_localization_data.lh2.data_ready[0][lh_index] == DB_LH2_PROCESSED_DATA_AVAILABLE && _localization_data.lh2.data_ready[1][lh_index] == DB_LH2_PROCESSED_DATA_AVAILABLE) {
+            out[n].lh_index = lh_index;
+            out[n].count1   = _localization_data.lh2.locations[0][lh_index].lfsr_counts;
+            out[n].count2   = _localization_data.lh2.locations[1][lh_index].lfsr_counts;
+            _localization_data.lh2.data_ready[0][lh_index] = DB_LH2_NO_NEW_DATA;
+            _localization_data.lh2.data_ready[1][lh_index] = DB_LH2_NO_NEW_DATA;
+            n++;
+        }
+    }
+    db_lh2_start();
+    return n;
 }

--- a/device/bootloader/Source/localization.h
+++ b/device/bootloader/Source/localization.h
@@ -29,10 +29,24 @@ typedef struct __attribute__((packed)) {
     int32_t homography_matrix[3][3];  ///< homography matrix, each element multiplied by 1e3
 } localization_homography_t;
 
+/// Raw LH2 LFSR counts for a single basestation (both sweeps), used for OTA calibration capture
+typedef struct __attribute__((packed)) {
+    uint8_t  lh_index;  ///< basestation index
+    uint32_t count1;    ///< sweep 0 LFSR count
+    uint32_t count2;    ///< sweep 1 LFSR count
+} lh2_raw_sample_t;
+
 void localization_init(int32_t homographies[][3][3], uint32_t homography_count);
+
+/// Start the LH2 driver without loading any calibration (idempotent). Used for raw capture in READY mode.
+void localization_start(void);
 
 bool localization_process_data(void);
 
 bool localization_get_position(position_2d_t *position);
+
+/// Drain the raw LFSR counts of every basestation that has both sweeps ready.
+/// Returns the number of samples written to @p out (capped at @p max), clearing the consumed data_ready flags.
+uint8_t localization_get_raw_counts(lh2_raw_sample_t *out, uint8_t max);
 
 #endif // __LOCALIZATION_H

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -54,6 +54,8 @@ typedef struct {
     bool            ota_require_erase;
     bool            ota_chunk_request;
     bool            lh2_calibration_ready;
+    bool            lh2_capture_request;
+    bool            lh2_capturing;
     bool            start_application;
     bool            system_reset_requested;
     position_2d_t   last_position;
@@ -261,7 +263,8 @@ int main(void) {
                             1 << IPC_CHAN_OTA_CHUNK |
                             1 << IPC_CHAN_APPLICATION_START |
                             1 << IPC_CHAN_SOC_RESET |
-                            1 << IPC_CHAN_CALIBRATION_DATA
+                            1 << IPC_CHAN_CALIBRATION_DATA |
+                            1 << IPC_CHAN_LH2_CAPTURE
                         );
     NRF_IPC_S->SEND_CNF[IPC_CHAN_REQ]                   = 1 << IPC_CHAN_REQ;
     NRF_IPC_S->SEND_CNF[IPC_CHAN_LOG_EVENT]             = 1 << IPC_CHAN_LOG_EVENT;
@@ -272,6 +275,7 @@ int main(void) {
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_START]          = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_CHUNK]          = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_CALIBRATION_DATA]   = 1 << IPC_CHAN_CALIBRATION_DATA;
+    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_LH2_CAPTURE]        = 1 << IPC_CHAN_LH2_CAPTURE;
     NVIC_EnableIRQ(IPC_IRQn);
     NVIC_ClearPendingIRQ(IPC_IRQn);
     NVIC_SetPriority(IPC_IRQn, IPC_IRQ_PRIORITY);
@@ -380,6 +384,12 @@ int main(void) {
             localization_init((int32_t (*)[3][3])ipc_shared_data.lh2_calibration.homographies, ipc_shared_data.lh2_calibration.homography_count);
         }
 
+        if (_bootloader_vars.lh2_capture_request) {
+            _bootloader_vars.lh2_capture_request = false;
+            localization_start();  // idempotent: starts LH2 even when no calibration is loaded
+            _bootloader_vars.lh2_capturing = true;
+        }
+
         if (_bootloader_vars.ota_start_request) {
             _bootloader_vars.ota_start_request = false;
 
@@ -458,6 +468,32 @@ int main(void) {
 
         // Process available lighthouse data
         bool data_available = localization_process_data();
+
+        // Raw LH2 capture for OTA calibration: drain the freshest counts and ship
+        // them to the host inside a LOG_EVENT. Cap samples so 1 tag + 9 bytes/sample
+        // fits in ipc_shared_data.log.data (INT8_MAX bytes).
+        if (_bootloader_vars.lh2_capturing && data_available) {
+            const uint8_t  max_samples = (INT8_MAX - 1) / 9;
+            lh2_raw_sample_t samples[LH2_BASESTATION_COUNT_MAX] = { 0 };
+            uint8_t count = localization_get_raw_counts(samples, max_samples < LH2_BASESTATION_COUNT_MAX ? max_samples : LH2_BASESTATION_COUNT_MAX);
+            if (count > 0) {
+                mutex_lock();
+                uint8_t length = 0;
+                ipc_shared_data.log.data[length++] = SWRMT_LH2_CALIB_TAG;
+                for (uint8_t i = 0; i < count; i++) {
+                    ipc_shared_data.log.data[length++] = samples[i].lh_index;
+                    memcpy((void *)&ipc_shared_data.log.data[length], &samples[i].count1, sizeof(uint32_t));
+                    length += sizeof(uint32_t);
+                    memcpy((void *)&ipc_shared_data.log.data[length], &samples[i].count2, sizeof(uint32_t));
+                    length += sizeof(uint32_t);
+                }
+                ipc_shared_data.log.length = length;
+                mutex_unlock();
+                NRF_IPC_S->TASKS_SEND[IPC_CHAN_LOG_EVENT] = 1;
+                _bootloader_vars.lh2_capturing = false;
+            }
+        }
+
         if (_bootloader_vars.position_update && data_available) {
             position_2d_t position = { 0 };
             bool valid_position = localization_get_position(&position);
@@ -502,5 +538,10 @@ void IPC_IRQHandler(void) {
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_CALIBRATION_DATA]) {
         NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_CALIBRATION_DATA] = 0;
         _bootloader_vars.lh2_calibration_ready = true;
+    }
+
+    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_LH2_CAPTURE]) {
+        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_LH2_CAPTURE] = 0;
+        _bootloader_vars.lh2_capture_request = true;
     }
 }

--- a/device/bootloader/Source/protocol.h
+++ b/device/bootloader/Source/protocol.h
@@ -26,6 +26,10 @@
 #define SWRMT_PREAMBLE_LENGTH       (8U)
 #define SWRMT_OTA_CHUNK_SIZE        (128U)
 
+/// First byte of a raw LH2 capture sample carried inside a LOG_EVENT payload.
+/// Lets the host tell a calibration sample apart from a regular text log line.
+#define SWRMT_LH2_CALIB_TAG         (0xCAU)
+
 typedef struct __attribute__((packed)) {
     uint32_t index;                             ///< Index of the chunk
     uint8_t  chunk_size;                        ///< Size of the chunk

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -42,6 +42,7 @@ typedef enum {
     IPC_CHAN_OTA_START          = 6,    ///< Channel used for starting an OTA process
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
     IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
+    IPC_CHAN_LH2_CAPTURE        = 9,    ///< Channel used to trigger a raw LH2 capture (READY mode only)
 } ipc_channels_t;
 
 typedef struct {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -99,7 +99,7 @@ static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length
         return;
     }
 
-    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_LH2_CALIBRATION)) {
+    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_LH2_CALIBRATION) || (packet_type == SWRMT_MSG_LH2_CAPTURE)) {
         _app_vars.req_received = true;
         return;
     }
@@ -227,6 +227,7 @@ int main(void) {
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_START]         = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_CHUNK]         = 1 << IPC_CHAN_OTA_CHUNK;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_CALIBRATION_DATA]  = 1 << IPC_CHAN_CALIBRATION_DATA;
+    NRF_IPC_NS->SEND_CNF[IPC_CHAN_LH2_CAPTURE]       = 1 << IPC_CHAN_LH2_CAPTURE;
     NRF_IPC_NS->RECEIVE_CNF[IPC_CHAN_REQ]            = 1 << IPC_CHAN_REQ;
     NRF_IPC_NS->RECEIVE_CNF[IPC_CHAN_LOG_EVENT]      = 1 << IPC_CHAN_LOG_EVENT;
 
@@ -400,6 +401,15 @@ int main(void) {
                         _commit_config_and_reboot();
                     }
                 } break;
+                case SWRMT_MSG_LH2_CAPTURE:
+                    // Raw LH2 capture only makes sense while the secure bootloader owns
+                    // the main loop (READY). In RUNNING the secure side has jumped to the
+                    // non-secure image and never services this channel.
+                    if (ipc_shared_data.status != SWRMT_APPLICATION_READY) {
+                        break;
+                    }
+                    NRF_IPC_NS->TASKS_SEND[IPC_CHAN_LH2_CAPTURE] = 1;
+                    break;
                 default:
                     break;
             }

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -44,6 +44,7 @@ typedef enum {
     // for the moment, I am just appending SWRMT_MSG_LH2_CALIBRATION after SWRMT_MESSAGE.
     SWRMT_MESSAGE = 0xA0, // custom message type
     SWRMT_MSG_LH2_CALIBRATION = 0xA1,
+    SWRMT_MSG_LH2_CAPTURE = 0xA2, // host -> node: capture one raw LH2 sample (READY mode only)
 } swrmt_message_type_t;
 
 /// Protocol packet type

--- a/swarmit/client/__init__.py
+++ b/swarmit/client/__init__.py
@@ -70,6 +70,14 @@ class SwarmitClient(Protocol):
 
     def send_lh2_calibration(self, blob: bytes) -> None: ...
 
+    def request_lh2_capture(self, device_addr: str) -> None:
+        """Trigger a raw LH2 capture on one device (READY mode only).
+
+        The bot answers with a SWARMIT_EVENT_LOG whose payload starts with
+        LH2_CALIB_TAG; callers consume it via watch_log_events().
+        """
+        ...
+
     def watch_status(
         self, interval: float = 0.5
     ) -> Iterator[dict[str, NodeStatus]]: ...

--- a/swarmit/client/http.py
+++ b/swarmit/client/http.py
@@ -206,6 +206,9 @@ class HTTPSwarmitClient:
         }
         self._request("POST", "/lh2_calibration", body=body)
 
+    def request_lh2_capture(self, device_addr: str) -> None:
+        self._request("POST", "/lh2_capture", body={"device": device_addr})
+
     def close(self) -> None:
         # No persistent connection to close (stdlib urllib opens per-request).
         pass

--- a/swarmit/client/local.py
+++ b/swarmit/client/local.py
@@ -166,6 +166,9 @@ class LocalSwarmitClient:
     def send_lh2_calibration(self, blob: bytes) -> None:
         self._controller.send_lh2_calibration(bytearray(blob))
 
+    def request_lh2_capture(self, device_addr: str) -> None:
+        self._controller.request_lh2_capture(device_addr)
+
     def watch_status(
         self, interval: float = 0.5
     ) -> Iterator[dict[str, NodeStatus]]:

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -25,6 +25,7 @@ from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.protocol import (
     DeviceType,
     PayloadCalibrationData,
+    PayloadLH2Capture,
     PayloadMessage,
     PayloadOTAChunk,
     PayloadOTAStart,
@@ -625,6 +626,16 @@ class Controller:
                 time.sleep(
                     0.3
                 )  # give the device some time to process the payload
+
+    def request_lh2_capture(self, device_addr: str):
+        """Trigger a single raw LH2 capture on one device.
+
+        The bot replies (only while READY) with a SWARMIT_EVENT_LOG whose
+        payload starts with LH2_CALIB_TAG. Delivery is best-effort: callers
+        await that log event and re-issue on timeout rather than relying on
+        this single send.
+        """
+        self.send_payload(int(device_addr, 16), PayloadLH2Capture())
 
     def _send_start_ota(
         self, device_addr: str, devices_to_flash: set[str], firmware: bytes

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -53,9 +53,18 @@ class PayloadType(IntEnum):
 
     # SwarmIT calibration data
     SWARMIT_LH2_CALIBRATION = 0xA1
+    # Host -> node: trigger a raw LH2 capture (READY mode only)
+    SWARMIT_LH2_CAPTURE = 0xA2
 
     # Marilib metrics probe
     METRICS_PROBE = MariDefaultPayloadType.METRICS_PROBE
+
+
+# First byte of a raw LH2 capture sample carried inside a SWARMIT_EVENT_LOG
+# payload. Mirrors SWRMT_LH2_CALIB_TAG in the swarmit bootloader firmware; lets
+# the host tell a calibration sample apart from a regular text log line. Each
+# sample that follows is [lh_index:1][count1:4 LE][count2:4 LE].
+LH2_CALIB_TAG = 0xCA
 
 
 # Requests
@@ -96,6 +105,11 @@ class PayloadEmpty(Payload):
 @dataclass
 class PayloadStart(PayloadEmpty):
     """Dataclass that holds an application start request packet."""
+
+
+@dataclass
+class PayloadLH2Capture(PayloadEmpty):
+    """Dataclass that holds a raw LH2 capture trigger (no body)."""
 
 
 @dataclass
@@ -251,4 +265,5 @@ register_parser(PayloadType.SWARMIT_OTA_CHUNK_ACK, PayloadOTAChunkAck)
 register_parser(PayloadType.SWARMIT_EVENT_LOG, PayloadEvent)
 register_parser(PayloadType.SWARMIT_MESSAGE, PayloadMessage)
 register_parser(PayloadType.SWARMIT_LH2_CALIBRATION, PayloadCalibrationData)
+register_parser(PayloadType.SWARMIT_LH2_CAPTURE, PayloadLH2Capture)
 register_parser(PayloadType.METRICS_PROBE, MetricsProbePayload)

--- a/swarmit/testbed/webserver.py
+++ b/swarmit/testbed/webserver.py
@@ -246,6 +246,15 @@ class Lh2CalibrationRequest(BaseModel):
     calibration_b64: str
 
 
+class CaptureRequest(BaseModel):
+    """Trigger a raw LH2 capture on a single device (READY mode only).
+
+    `device` is the hex device address, e.g. "BC3D3C8A2A6F8E68".
+    """
+
+    device: str
+
+
 @api.post("/flash", dependencies=[Depends(verify_jwt)])
 async def flash_firmware(payload: FlashRequest, request: Request):
     controller: Controller = request.app.state.controller
@@ -543,6 +552,14 @@ async def lh2_calibration(request: Request, payload: Lh2CalibrationRequest):
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
+    return JSONResponse(content={"response": "done"})
+
+
+@api.post("/lh2_capture", dependencies=[Depends(verify_jwt)])
+async def lh2_capture(request: Request, payload: CaptureRequest):
+    controller: Controller = request.app.state.controller
+    async with controller_lock:
+        await run_in_threadpool(controller.request_lh2_capture, payload.device)
     return JSONResponse(content={"response": "done"})
 
 


### PR DESCRIPTION
## Summary
- Adds an over-the-air "capture raw LH2 counts" round trip so a single DotBot can be LH2-calibrated without a serial cable. The host triggers a capture; the bot samples its own raw counts and ships them back inside a `LOG_EVENT`.
- Firmware: the secure bootloader reads its own raw LH2 counts on request (READY mode only, where the secure loop runs) and emits them via `IPC_CHAN_LOG_EVENT`; the network core relays the trigger to the bootloader. No `cmse_implib.a` / NSC veneer change, so the deployed app-loader NSC region layout is untouched.
- Python transport: new `request_lh2_capture(device_addr)` wired through the client backends (local + HTTP), a `SWRMT_MSG_LH2_CAPTURE` trigger in the controller, the `/events` stream already carries the reply, and `LH2_CALIB_TAG` marks the raw-count `log_event` payload.

This is the transport half of single-bot OTA LH2 calibration. The host-side capture/solve/save and the `dotbot swarm lh2-calibration` CLI live in PyDotBot (DotBots/PyDotBot#271), which imports `request_lh2_capture` + `LH2_CALIB_TAG` from here.

## Merge order
Merge this **before** PyDotBot#271 - that PR's runtime imports these symbols.

## Constraint
Capture runs only while the bot is **READY** (idle); RUNNING never enters the secure loop. Needs a one-time bootloader + net-core J-Link reflash (no sandbox blob reship).

## Test plan
- [x] Reflash bootloader + net core; with a bot in READY, `request_lh2_capture(<addr>)` returns a tagged `log_event` of raw counts.
- [x] End-to-end via PyDotBot#271: collect 4 corners, solve, save, push, bot reports a position.