### PR TITLE
swarmit: report crash cause in status frames

### DIFF
--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -74,7 +74,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
     uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
-    uint8_t  from_ns;       ///< 1 if the faulting context was non-secure (PC resolves against the app image)
+    uint8_t  from_ns;       ///< 1 = non-secure user app faulted (resolve pc/lr against the app .elf); 0 = secure bootloader
     uint32_t cfsr;          ///< Configurable Fault Status Register at fault
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -70,6 +70,16 @@ typedef struct __attribute__((packed)) {
     uint8_t buffer[UINT8_MAX];  ///< Buffer containing the pdu data
 } ipc_radio_pdu_t;
 
+/// Crash report describing the most recent reset, appended to status frames
+typedef struct __attribute__((packed)) {
+    uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
+    uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
+    uint32_t cfsr;          ///< Configurable Fault Status Register at fault
+    uint32_t sfsr;          ///< Secure Fault Status Register at fault
+    uint32_t pc;            ///< Stacked program counter at fault
+    uint32_t lr;            ///< Stacked link register at fault
+} ipc_crash_report_t;
+
 typedef struct __attribute__((packed,aligned(8))) {
     bool                    net_ready;          ///< Network core is ready
     bool                    net_ack;            ///< Network core acked the latest request
@@ -85,6 +95,7 @@ typedef struct __attribute__((packed,aligned(8))) {
     ipc_radio_pdu_t         tx_pdu;             ///< TX PDU
     ipc_radio_pdu_t         rx_pdu;             ///< RX PDU
     ipc_lh2_calibration_t  lh2_calibration;     ///< LH2 calibration data
+    ipc_crash_report_t      crash_report;       ///< Cause of the most recent reset
 } ipc_shared_data_t;
 
 void mutex_lock(void);

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -74,6 +74,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
     uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
+    uint8_t  from_ns;       ///< 1 if the faulting context was non-secure (PC resolves against the app image)
     uint32_t cfsr;          ///< Configurable Fault Status Register at fault
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -326,11 +326,12 @@ int main(void) {
     // the previous run latched one before the watchdog fired.
     ipc_shared_data.crash_report.reset_reason = resetreas;
     if (crash_latch.magic == CRASH_LATCH_MAGIC) {
-        ipc_shared_data.crash_report.fault = (uint8_t)crash_latch.fault;
-        ipc_shared_data.crash_report.cfsr  = crash_latch.cfsr;
-        ipc_shared_data.crash_report.sfsr  = crash_latch.sfsr;
-        ipc_shared_data.crash_report.pc    = crash_latch.pc;
-        ipc_shared_data.crash_report.lr    = crash_latch.lr;
+        ipc_shared_data.crash_report.fault   = (uint8_t)crash_latch.fault;
+        ipc_shared_data.crash_report.from_ns = (uint8_t)crash_latch.from_ns;
+        ipc_shared_data.crash_report.cfsr    = crash_latch.cfsr;
+        ipc_shared_data.crash_report.sfsr    = crash_latch.sfsr;
+        ipc_shared_data.crash_report.pc      = crash_latch.pc;
+        ipc_shared_data.crash_report.lr      = crash_latch.lr;
     }
     crash_latch.magic = 0;
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -28,6 +28,8 @@
 #include "localization.h"
 #include "timer.h"
 
+#include "../System/crash_latch.h"
+
 #define SWARMIT_BASE_ADDRESS            (0x10000)
 #define SWARMIT_CONFIG_START_ADDRESS    (0x0103f800) // start of the last page (2KB) of the flash (0x01000000 + 0x00040000 - 0x800)
 
@@ -318,6 +320,19 @@ int main(void) {
     // Check reset reason and switch to user image if reset was not triggered by any wdt timeout
     uint32_t resetreas = NRF_RESET_S->RESETREAS;
     NRF_RESET_S->RESETREAS = NRF_RESET_S->RESETREAS;
+
+    // Publish the cause of the reset that brought us here; the network core
+    // appends it to every status frame. The fault snapshot is only valid when
+    // the previous run latched one before the watchdog fired.
+    ipc_shared_data.crash_report.reset_reason = resetreas;
+    if (crash_latch.magic == CRASH_LATCH_MAGIC) {
+        ipc_shared_data.crash_report.fault = (uint8_t)crash_latch.fault;
+        ipc_shared_data.crash_report.cfsr  = crash_latch.cfsr;
+        ipc_shared_data.crash_report.sfsr  = crash_latch.sfsr;
+        ipc_shared_data.crash_report.pc    = crash_latch.pc;
+        ipc_shared_data.crash_report.lr    = crash_latch.lr;
+    }
+    crash_latch.magic = 0;
 
     // Consume the boot intent set by whoever requested this reset (or random
     // RAM on first power-on, which won't match either magic value).

--- a/device/bootloader/System/crash_latch.h
+++ b/device/bootloader/System/crash_latch.h
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * @author  Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @brief   Crash latch preserved across the watchdog reset that follows a fault
+ *
+ * The fault handlers snapshot the fault state here. The latch lives in the
+ * .non_init RAM section (load="No" in flash_placement.xml, skipped by the
+ * startup zeroing loops) so it survives the reset and lets the bootloader
+ * publish the crash cause to the network core on the next boot.
+ *
+ * @copyright Inria, 2026
+ *
+ */
+
+#ifndef __CRASH_LATCH_H
+#define __CRASH_LATCH_H
+
+#include <stdint.h>
+
+#define CRASH_LATCH_MAGIC (0xFA170BADUL)
+
+typedef enum {
+    CRASH_FAULT_NONE   = 0,
+    CRASH_FAULT_HARD   = 1,
+    CRASH_FAULT_SECURE = 2,
+} crash_fault_t;
+
+typedef struct {
+    uint32_t magic;  ///< Equals CRASH_LATCH_MAGIC when the latch holds a valid snapshot
+    uint32_t fault;  ///< crash_fault_t value
+    uint32_t cfsr;   ///< Configurable Fault Status Register (MMFSR, BFSR, UFSR)
+    uint32_t sfsr;   ///< Secure Fault Status Register
+    uint32_t pc;     ///< Stacked program counter at fault (0 if unavailable)
+    uint32_t lr;     ///< Stacked link register at fault (0 if unavailable)
+} crash_latch_t;
+
+extern volatile crash_latch_t crash_latch;
+
+/**
+ * @brief Snapshot the current fault state into the crash latch
+ *
+ * @param[in]   fault   crash_fault_t value identifying the handler
+ * @param[in]   sp      Stack pointer holding the exception stack frame
+ */
+void crash_latch_fault(uint32_t fault, uint32_t *sp);
+
+#endif  // __CRASH_LATCH_H

--- a/device/bootloader/System/crash_latch.h
+++ b/device/bootloader/System/crash_latch.h
@@ -20,15 +20,15 @@
 #define CRASH_LATCH_MAGIC (0xFA170BADUL)
 
 typedef enum {
-    CRASH_FAULT_NONE   = 0,
-    CRASH_FAULT_HARD   = 1,
-    CRASH_FAULT_SECURE = 2,
+    CRASH_FAULT_NONE   = 0,  ///< No fault caught - clean reset (power-on, pin, stop, soft-reset)
+    CRASH_FAULT_HARD   = 1,  ///< Secure HardFault, e.g. a bus/usage fault escalated in secure or NSC code
+    CRASH_FAULT_SECURE = 2,  ///< SecureFault, e.g. the app writing into secure memory (a NULL store hits AUVIOL)
 } crash_fault_t;
 
 typedef struct {
     uint32_t magic;    ///< Equals CRASH_LATCH_MAGIC when the latch holds a valid snapshot
     uint32_t fault;    ///< crash_fault_t value
-    uint32_t from_ns;  ///< 1 if the faulting context was non-secure (PC resolves against the app image)
+    uint32_t from_ns;  ///< 1 = non-secure user app faulted (resolve pc/lr against the app .elf); 0 = secure bootloader
     uint32_t cfsr;     ///< Configurable Fault Status Register (MMFSR, BFSR, UFSR)
     uint32_t sfsr;     ///< Secure Fault Status Register
     uint32_t pc;       ///< Stacked program counter at fault (0 if unavailable)

--- a/device/bootloader/System/crash_latch.h
+++ b/device/bootloader/System/crash_latch.h
@@ -26,12 +26,13 @@ typedef enum {
 } crash_fault_t;
 
 typedef struct {
-    uint32_t magic;  ///< Equals CRASH_LATCH_MAGIC when the latch holds a valid snapshot
-    uint32_t fault;  ///< crash_fault_t value
-    uint32_t cfsr;   ///< Configurable Fault Status Register (MMFSR, BFSR, UFSR)
-    uint32_t sfsr;   ///< Secure Fault Status Register
-    uint32_t pc;     ///< Stacked program counter at fault (0 if unavailable)
-    uint32_t lr;     ///< Stacked link register at fault (0 if unavailable)
+    uint32_t magic;    ///< Equals CRASH_LATCH_MAGIC when the latch holds a valid snapshot
+    uint32_t fault;    ///< crash_fault_t value
+    uint32_t from_ns;  ///< 1 if the faulting context was non-secure (PC resolves against the app image)
+    uint32_t cfsr;     ///< Configurable Fault Status Register (MMFSR, BFSR, UFSR)
+    uint32_t sfsr;     ///< Secure Fault Status Register
+    uint32_t pc;       ///< Stacked program counter at fault (0 if unavailable)
+    uint32_t lr;       ///< Stacked link register at fault (0 if unavailable)
 } crash_latch_t;
 
 extern volatile crash_latch_t crash_latch;
@@ -39,9 +40,13 @@ extern volatile crash_latch_t crash_latch;
 /**
  * @brief Snapshot the current fault state into the crash latch
  *
- * @param[in]   fault   crash_fault_t value identifying the handler
- * @param[in]   sp      Stack pointer holding the exception stack frame
+ * @param[in]   fault       crash_fault_t value identifying the handler
+ * @param[in]   sp          Stack frame of the faulting context (already
+ *                          resolved to the secure or non-secure stack by the
+ *                          handler trampoline)
+ * @param[in]   exc_return  EXC_RETURN seen on handler entry; bit 6 (S) tells
+ *                          whether the faulting context was secure
  */
-void crash_latch_fault(uint32_t fault, uint32_t *sp);
+void crash_latch_fault(uint32_t fault, uint32_t *sp, uint32_t exc_return);
 
 #endif  // __CRASH_LATCH_H

--- a/device/bootloader/System/fault_handlers.c
+++ b/device/bootloader/System/fault_handlers.c
@@ -15,12 +15,13 @@
 
 volatile crash_latch_t crash_latch __attribute__((section(".non_init")));
 
-void crash_latch_fault(uint32_t fault, uint32_t *sp) {
-    crash_latch.fault = fault;
-    crash_latch.cfsr  = SCB->CFSR;
-    crash_latch.sfsr  = SCB->SFSR;
-    crash_latch.pc    = 0;
-    crash_latch.lr    = 0;
+void crash_latch_fault(uint32_t fault, uint32_t *sp, uint32_t exc_return) {
+    crash_latch.fault   = fault;
+    crash_latch.from_ns = (exc_return & (1u << 6)) ? 0u : 1u;  // EXC_RETURN.S clear => non-secure background
+    crash_latch.cfsr    = SCB->CFSR;
+    crash_latch.sfsr    = SCB->SFSR;
+    crash_latch.pc      = 0;
+    crash_latch.lr      = 0;
     // Magic is set before touching the stacked frame: reading it can fault
     // again (e.g. after a stacking error), in which case the latch stays
     // valid with pc/lr zeroed.
@@ -29,13 +30,13 @@ void crash_latch_fault(uint32_t fault, uint32_t *sp) {
     crash_latch.pc    = sp[6];
 }
 
-void HardFaultHandler(uint32_t *sp) {
+void HardFaultHandler(uint32_t *sp, uint32_t exc_return) {
     if (SCB->HFSR & (SCB_HFSR_DEBUGEVT_Msk)) {
         SCB->HFSR |=  (SCB_HFSR_DEBUGEVT_Msk);      // Reset Hard Fault status
         *(sp + 6u) += 2u;                           // PC is located on stack at SP + 24 bytes. Increment PC by 2 to skip break instruction.
         return;                                     // Return to interrupted application
     }
-    crash_latch_fault(CRASH_FAULT_HARD, sp);
+    crash_latch_fault(CRASH_FAULT_HARD, sp, exc_return);
 #if defined(DEBUG)
     hardfault_regs.shcsr.word    = SCB->SHCSR;  // System Handler Control and State Register
     hardfault_regs.mmfsr.byte    = (uint8_t)(SCB->SHCSR & 0xFF);   // MemManage Fault Status Register
@@ -63,8 +64,8 @@ void HardFaultHandler(uint32_t *sp) {
 }
 
 
-void SecureFaultHandler(uint32_t* sp) {
-    crash_latch_fault(CRASH_FAULT_SECURE, sp);
+void SecureFaultHandler(uint32_t* sp, uint32_t exc_return) {
+    crash_latch_fault(CRASH_FAULT_SECURE, sp, exc_return);
 #if defined(DEBUG)
     securefault_reg.sfsr.word    = SCB->SFSR;   // System Handler Control and State Register
     hardfault_regs.regs.r0       = sp[0];       // Register R0

--- a/device/bootloader/System/fault_handlers.c
+++ b/device/bootloader/System/fault_handlers.c
@@ -10,7 +10,24 @@
  */
 
 #include <nrf.h>
+#include "crash_latch.h"
 #include "fault_handlers.h"
+
+volatile crash_latch_t crash_latch __attribute__((section(".non_init")));
+
+void crash_latch_fault(uint32_t fault, uint32_t *sp) {
+    crash_latch.fault = fault;
+    crash_latch.cfsr  = SCB->CFSR;
+    crash_latch.sfsr  = SCB->SFSR;
+    crash_latch.pc    = 0;
+    crash_latch.lr    = 0;
+    // Magic is set before touching the stacked frame: reading it can fault
+    // again (e.g. after a stacking error), in which case the latch stays
+    // valid with pc/lr zeroed.
+    crash_latch.magic = CRASH_LATCH_MAGIC;
+    crash_latch.lr    = sp[5];
+    crash_latch.pc    = sp[6];
+}
 
 void HardFaultHandler(uint32_t *sp) {
     if (SCB->HFSR & (SCB_HFSR_DEBUGEVT_Msk)) {
@@ -18,6 +35,7 @@ void HardFaultHandler(uint32_t *sp) {
         *(sp + 6u) += 2u;                           // PC is located on stack at SP + 24 bytes. Increment PC by 2 to skip break instruction.
         return;                                     // Return to interrupted application
     }
+    crash_latch_fault(CRASH_FAULT_HARD, sp);
 #if defined(DEBUG)
     hardfault_regs.shcsr.word    = SCB->SHCSR;  // System Handler Control and State Register
     hardfault_regs.mmfsr.byte    = (uint8_t)(SCB->SHCSR & 0xFF);   // MemManage Fault Status Register
@@ -46,6 +64,7 @@ void HardFaultHandler(uint32_t *sp) {
 
 
 void SecureFaultHandler(uint32_t* sp) {
+    crash_latch_fault(CRASH_FAULT_SECURE, sp);
 #if defined(DEBUG)
     securefault_reg.sfsr.word    = SCB->SFSR;   // System Handler Control and State Register
     hardfault_regs.regs.r0       = sp[0];       // Register R0

--- a/device/bootloader/System/fault_handlers.h
+++ b/device/bootloader/System/fault_handlers.h
@@ -158,7 +158,7 @@ static struct {
 } securefault_reg;
 #endif
 
-void HardFaultHandler(uint32_t* sp);
-void SecureFaultHandler(uint32_t* sp);
+void HardFaultHandler(uint32_t* sp, uint32_t exc_return);
+void SecureFaultHandler(uint32_t* sp, uint32_t exc_return);
 
 #endif // __FAULT_HANDLERS_H

--- a/device/bootloader/System/startup.c
+++ b/device/bootloader/System/startup.c
@@ -308,23 +308,49 @@ void Reset_Handler(void) {
 }
 
 // Exception handlers
+//
+// The trampolines resolve the faulting context's stack frame and pass it in R0
+// plus EXC_RETURN in R1. EXC_RETURN bit 6 (S) tells whether the background was
+// secure: when a non-secure access faults into the secure handler the frame
+// lives on the non-secure stack, so we must read MSP_NS/PSP_NS instead of the
+// banked secure SP - otherwise the captured PC reads off the wrong stack as 0.
 void HardFault_Handler(void) {
     __ASM(
-         "tst    LR, #4             ;"  // Check EXC_RETURN in Link register bit 2.
+         "tst    LR, #0x40          ;"  // EXC_RETURN bit 6 (S): secure background?
+         "bne    1f                 ;"
+         "tst    LR, #4             ;"  // non-secure background: pick NS stack
          "ite    EQ                 ;"
-         "mrseq  R0, MSP            ;"  // Stacking was using MSP.
-         "mrsne  R0, PSP            ;"  // Stacking was using PSP.
-         "b      HardFaultHandler   ;"  // Stack pointer passed through R0.
+         "mrseq  R0, MSP_NS         ;"
+         "mrsne  R0, PSP_NS         ;"
+         "b      2f                 ;"
+         "1:                        ;"
+         "tst    LR, #4             ;"  // secure background: pick secure stack
+         "ite    EQ                 ;"
+         "mrseq  R0, MSP            ;"
+         "mrsne  R0, PSP            ;"
+         "2:                        ;"
+         "mov    R1, LR             ;"  // EXC_RETURN passed through R1.
+         "b      HardFaultHandler   ;"  // Stack frame passed through R0.
     );
 }
 
 void SecureFault_Handler(void) {
     __ASM(
-         "tst    LR, #4             ;"  // Check EXC_RETURN in Link register bit 2.
+         "tst    LR, #0x40          ;"  // EXC_RETURN bit 6 (S): secure background?
+         "bne    1f                 ;"
+         "tst    LR, #4             ;"  // non-secure background: pick NS stack
          "ite    EQ                 ;"
-         "mrseq  R0, MSP            ;"  // Stacking was using MSP.
-         "mrsne  R0, PSP            ;"  // Stacking was using PSP.
-         "b      SecureFaultHandler ;"  // Stack pointer passed through R0.
+         "mrseq  R0, MSP_NS         ;"
+         "mrsne  R0, PSP_NS         ;"
+         "b      2f                 ;"
+         "1:                        ;"
+         "tst    LR, #4             ;"  // secure background: pick secure stack
+         "ite    EQ                 ;"
+         "mrseq  R0, MSP            ;"
+         "mrsne  R0, PSP            ;"
+         "2:                        ;"
+         "mov    R1, LR             ;"  // EXC_RETURN passed through R1.
+         "b      SecureFaultHandler ;"  // Stack frame passed through R0.
     );
 }
 

--- a/device/bootloader/bootloader-app.emProject
+++ b/device/bootloader/bootloader-app.emProject
@@ -37,6 +37,7 @@
     <folder Name="System">
       <file file_name="System/clock.c" />
       <file file_name="System/clock.h" />
+      <file file_name="System/crash_latch.h" />
       <file file_name="System/fault_handlers.c" />
       <file file_name="System/fault_handlers.h" />
       <file file_name="System/startup.c" />

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -84,6 +84,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
     uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
+    uint8_t  from_ns;       ///< 1 if the faulting context was non-secure (PC resolves against the app image)
     uint32_t cfsr;          ///< Configurable Fault Status Register at fault
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -84,7 +84,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
     uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
-    uint8_t  from_ns;       ///< 1 if the faulting context was non-secure (PC resolves against the app image)
+    uint8_t  from_ns;       ///< 1 = non-secure user app faulted (resolve pc/lr against the app .elf); 0 = secure bootloader
     uint32_t cfsr;          ///< Configurable Fault Status Register at fault
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -80,6 +80,16 @@ typedef struct __attribute__((packed)) {
     uint32_t y;  ///< Y coordinate in mm
 } position_2d_t;
 
+/// Crash report describing the most recent reset, appended to status frames
+typedef struct __attribute__((packed)) {
+    uint32_t reset_reason;  ///< RESETREAS value captured at boot (0 means power-on)
+    uint8_t  fault;         ///< Fault latched before the reset (0: none, 1: hard fault, 2: secure fault)
+    uint32_t cfsr;          ///< Configurable Fault Status Register at fault
+    uint32_t sfsr;          ///< Secure Fault Status Register at fault
+    uint32_t pc;            ///< Stacked program counter at fault
+    uint32_t lr;            ///< Stacked link register at fault
+} ipc_crash_report_t;
+
 typedef struct __attribute__((packed)) {
     bool                    net_ready;          ///< Network core is ready
     bool                    net_ack;            ///< Network core acked the latest request
@@ -95,6 +105,7 @@ typedef struct __attribute__((packed)) {
     ipc_radio_pdu_t         tx_pdu;             ///< TX pdu
     ipc_radio_pdu_t         rx_pdu;             ///< RX pdu
     ipc_lh2_calibration_t    lh2_calibration;     ///< LH2 calibration data
+    ipc_crash_report_t      crash_report;       ///< Cause of the most recent reset
 } ipc_shared_data_t;
 
 /**

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -266,6 +266,8 @@ int main(void) {
             length += sizeof(uint16_t);
             memcpy(&_app_vars.notification_buffer[length], (void *)&ipc_shared_data.current_position, sizeof(position_2d_t));
             length += sizeof(position_2d_t);
+            memcpy(&_app_vars.notification_buffer[length], (void *)&ipc_shared_data.crash_report, sizeof(ipc_crash_report_t));
+            length += sizeof(ipc_crash_report_t);
             mari_node_tx_payload(_app_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
         }
 

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -23,6 +23,7 @@ from swarmit.testbed.controller import (
     ControllerSettings,
     NodeStatus,
     ResetLocation,
+    generate_inspect,
     generate_status,
 )
 from swarmit.testbed.helpers import (
@@ -606,6 +607,21 @@ def status(ctx, watch):
         else:
             print(generate_status(client.status(), settings.devices))
             print()
+
+
+@main.command()
+@click.pass_context
+def inspect(ctx):
+    """Dump full detail for the selected device(s).
+
+    Everything from the status packet plus the raw crash report (decoded
+    reset reason, fault status registers, and faulting PC/LR). Scope it
+    with the group's -d/--devices option, e.g.
+    `swarmit -d <addr> inspect`; with no -d it dumps every known device.
+    """
+    settings = ctx.obj["settings"]
+    with build_client(settings, no_server=ctx.obj["no_server"]) as client:
+        print(generate_inspect(client.status(), settings.devices))
 
 
 @main.command()

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -23,7 +23,7 @@ from swarmit.testbed.controller import (
     ControllerSettings,
     NodeStatus,
     ResetLocation,
-    generate_inspect,
+    generate_info,
     generate_status,
 )
 from swarmit.testbed.helpers import (
@@ -611,17 +611,17 @@ def status(ctx, watch):
 
 @main.command()
 @click.pass_context
-def inspect(ctx):
-    """Dump full detail for the selected device(s).
+def info(ctx):
+    """Show full detail for the selected device(s).
 
     Everything from the status packet plus the raw crash report (decoded
     reset reason, fault status registers, and faulting PC/LR). Scope it
-    with the group's -d/--devices option, e.g.
-    `swarmit -d <addr> inspect`; with no -d it dumps every known device.
+    with the group's -d/--devices option, e.g. `swarm -d <addr> info`;
+    with no -d it shows every known device.
     """
     settings = ctx.obj["settings"]
     with build_client(settings, no_server=ctx.obj["no_server"]) as client:
-        print(generate_inspect(client.status(), settings.devices))
+        print(generate_info(client.status(), settings.devices))
 
 
 @main.command()

--- a/swarmit/client/http.py
+++ b/swarmit/client/http.py
@@ -260,6 +260,7 @@ def _parse_node_status(d: dict) -> NodeStatus:
         pos_y=d["pos_y"],
         reset_reason=d.get("reset_reason", 0),
         fault=d.get("fault", 0),
+        from_ns=d.get("from_ns", 0),
         cfsr=d.get("cfsr", 0),
         sfsr=d.get("sfsr", 0),
         pc=d.get("pc", 0),

--- a/swarmit/client/http.py
+++ b/swarmit/client/http.py
@@ -258,5 +258,11 @@ def _parse_node_status(d: dict) -> NodeStatus:
         battery=d["battery"],
         pos_x=d["pos_x"],
         pos_y=d["pos_y"],
+        reset_reason=d.get("reset_reason", 0),
+        fault=d.get("fault", 0),
+        cfsr=d.get("cfsr", 0),
+        sfsr=d.get("sfsr", 0),
+        pc=d.get("pc", 0),
+        lr=d.get("lr", 0),
         last_updated_at=d["last_updated_at"],
     )

--- a/swarmit/client/http.py
+++ b/swarmit/client/http.py
@@ -265,5 +265,6 @@ def _parse_node_status(d: dict) -> NodeStatus:
         sfsr=d.get("sfsr", 0),
         pc=d.get("pc", 0),
         lr=d.get("lr", 0),
+        raw=d.get("raw", ""),
         last_updated_at=d["last_updated_at"],
     )

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -24,6 +24,7 @@ from swarmit.testbed.adapter import (
 from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.protocol import (
     DeviceType,
+    FaultType,
     PayloadCalibrationData,
     PayloadLH2Capture,
     PayloadMessage,
@@ -34,6 +35,7 @@ from swarmit.testbed.protocol import (
     PayloadStop,
     PayloadType,
     StatusType,
+    decode_reset_reason,
 )
 
 CHUNK_SIZE = 128
@@ -61,6 +63,12 @@ class NodeStatus:
     battery: int = 0
     pos_x: int = 0
     pos_y: int = 0
+    reset_reason: int = 0
+    fault: int = 0
+    cfsr: int = 0
+    sfsr: int = 0
+    pc: int = 0
+    lr: int = 0
     last_updated_at: float = 0
 
 
@@ -129,6 +137,27 @@ def battery_level_color(level: int):
     return "red"
 
 
+def format_reset_cause(device_data) -> str:
+    """Format the last reset cause of a node, including any latched fault."""
+    text = decode_reset_reason(device_data.reset_reason)
+    if device_data.fault:
+        try:
+            fault_name = FaultType(device_data.fault).name
+        except ValueError:
+            fault_name = f"fault {device_data.fault}"
+        text += f" ({fault_name} pc=0x{device_data.pc:08x})"
+    return text
+
+
+def reset_cause_color(device_data) -> str:
+    suspicious = (
+        device_data.fault
+        # watchdog0, lockup, watchdog1
+        or device_data.reset_reason & ((1 << 1) | (1 << 4) | (1 << 25))
+    )
+    return "red" if suspicious else "cyan"
+
+
 def generate_status(status_data, devices=[], status_message="found"):
     data = {
         addr: device_data
@@ -165,6 +194,11 @@ def generate_status(status_data, devices=[], status_message="found"):
         justify="center",
         width=max([len(m) for m in StatusType.__members__]),
     )
+    table.add_column(
+        "Last reset",
+        style="cyan",
+        justify="center",
+    )
     for device_addr, device_data in sorted(data.items()):
 
         table.add_row(
@@ -173,6 +207,7 @@ def generate_status(status_data, devices=[], status_message="found"):
             f"[{battery_level_color(device_data.battery)}]{device_data.battery / 1000:.2f}V ({int(device_data.battery / 3000 * 100)}%)",
             f"({device_data.pos_x}, {device_data.pos_y})",
             f"{'[bold cyan]' if device_data.status == StatusType.Running else '[bold green]'}{device_data.status.name}",
+            f"[{reset_cause_color(device_data)}]{format_reset_cause(device_data)}",
         )
     return Group(header, table)
 
@@ -384,6 +419,12 @@ class Controller:
                 battery=packet.payload.battery,
                 pos_x=packet.payload.pos_x,
                 pos_y=packet.payload.pos_y,
+                reset_reason=packet.payload.reset_reason,
+                fault=packet.payload.fault,
+                cfsr=packet.payload.cfsr,
+                sfsr=packet.payload.sfsr,
+                pc=packet.payload.pc,
+                lr=packet.payload.lr,
                 last_updated_at=now,
             )
             self.status_data.update({device_addr: status})

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -167,12 +167,16 @@ def format_reset_cause(device_data) -> str:
     rr = device_data.reset_reason
     # Crash wins over everything: a stop racing a crash can set both bits.
     if device_data.fault or (rr & _RR_WDT0):
+        # Surface the raw reset reason too (watchdog0 for the crash deadman,
+        # lockup if the fault handler itself wedged) - it disambiguates the
+        # crash path at a glance.
+        reset_name = decode_reset_reason(rr)
         if device_data.fault:
             return (
-                f"crashed ({_fault_name(device_data)} "
+                f"crashed ({reset_name} {_fault_name(device_data)} "
                 f"pc=0x{device_data.pc:08x})"
             )
-        return "crashed (hang)"
+        return f"crashed ({reset_name})"
     if rr & _RR_WDT1:
         return "stopped"
     if rr & _RR_LOCKUP:
@@ -261,7 +265,7 @@ def generate_inspect(status_data, devices=[]):
     if not data:
         return Group(Text("\nNo matching device\n"))
 
-    panels = []
+    panels = [Text("")]
     for device_addr, d in sorted(data.items()):
         table = Table(show_header=False, box=None, pad_edge=False)
         table.add_column("field", style="bold cyan", no_wrap=True)

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -12,6 +12,7 @@ from dotbot_utils.serial_interface import get_default_port
 from rich import print
 from rich.console import Group
 from rich.live import Live
+from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 from tqdm import tqdm
@@ -271,7 +272,6 @@ def generate_info(status_data, devices=[]):
         table.add_column("field", style="bold cyan", no_wrap=True)
         table.add_column("value")
 
-        table.add_row("Device", device_addr)
         table.add_row("Type", d.device.name)
         table.add_row("Status", d.status.name)
         table.add_row(
@@ -320,7 +320,16 @@ def generate_info(status_data, devices=[]):
             )
             table.add_row("", "")
             table.add_row("Raw status pkt", spaced)
-        panels.append(table)
+        panels.append(
+            Panel(
+                table,
+                title=f"[bold magenta]{device_addr}[/]",
+                title_align="left",
+                border_style="cyan",
+                padding=(0, 1),
+                expand=False,
+            )
+        )
         panels.append(Text(""))
     return Group(*panels)
 

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -72,6 +72,7 @@ class NodeStatus:
     sfsr: int = 0
     pc: int = 0
     lr: int = 0
+    raw: str = ""  # hex of the full status packet as received
     last_updated_at: float = 0
 
 
@@ -308,6 +309,13 @@ def generate_inspect(status_data, devices=[]):
             elf = "app image" if d.from_ns else "bootloader image"
             table.add_row("  pc", f"0x{d.pc:08x}  (resolve against {elf})")
             table.add_row("  lr", f"0x{d.lr:08x}")
+
+        if d.raw:
+            spaced = " ".join(
+                d.raw[i : i + 2] for i in range(0, len(d.raw), 2)
+            )
+            table.add_row("", "")
+            table.add_row("Raw status pkt", spaced)
         panels.append(table)
         panels.append(Text(""))
     return Group(*panels)
@@ -527,6 +535,7 @@ class Controller:
                 sfsr=packet.payload.sfsr,
                 pc=packet.payload.pc,
                 lr=packet.payload.lr,
+                raw=packet.to_bytes().hex(),
                 last_updated_at=now,
             )
             self.status_data.update({device_addr: status})

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -250,7 +250,7 @@ def generate_status(status_data, devices=[], status_message="found"):
     return Group(header, table)
 
 
-def generate_inspect(status_data, devices=[]):
+def generate_info(status_data, devices=[]):
     """Full per-device detail: every status field plus the raw crash report.
 
     The status table shows a friendly one-line reset cause; this dumps

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -35,7 +35,9 @@ from swarmit.testbed.protocol import (
     PayloadStop,
     PayloadType,
     StatusType,
+    decode_cfsr,
     decode_reset_reason,
+    decode_sfsr,
 )
 
 CHUNK_SIZE = 128
@@ -65,6 +67,7 @@ class NodeStatus:
     pos_y: int = 0
     reset_reason: int = 0
     fault: int = 0
+    from_ns: int = 0
     cfsr: int = 0
     sfsr: int = 0
     pc: int = 0
@@ -137,25 +140,55 @@ def battery_level_color(level: int):
     return "red"
 
 
+# RESETREAS bit masks with a swarmit-specific meaning (see the bootloader's
+# two watchdogs: WDT0 is the crash deadman the running app must pet, WDT1 is
+# started by the stop command's DPPI path and nothing else).
+_RR_WDT0 = 1 << 1  # crash / hang: app stopped petting the deadman
+_RR_WDT1 = 1 << 25  # stop command (only thing that starts WDT1)
+_RR_LOCKUP = 1 << 4
+_RR_SREQ = 1 << 3  # soft reset: start_application or calibration-commit reboot
+_RR_PIN = 1 << 0
+
+
+def _fault_name(device_data) -> str:
+    try:
+        return FaultType(device_data.fault).name
+    except ValueError:
+        return f"fault{device_data.fault}"
+
+
 def format_reset_cause(device_data) -> str:
-    """Format the last reset cause of a node, including any latched fault."""
-    text = decode_reset_reason(device_data.reset_reason)
-    if device_data.fault:
-        try:
-            fault_name = FaultType(device_data.fault).name
-        except ValueError:
-            fault_name = f"fault {device_data.fault}"
-        text += f" ({fault_name} pc=0x{device_data.pc:08x})"
-    return text
+    """Friendly one-line label for a node's last reset cause.
+
+    Maps the raw RESETREAS + latched fault onto swarmit semantics. The raw
+    values stay available in the inspect view for low-level debugging.
+    """
+    rr = device_data.reset_reason
+    # Crash wins over everything: a stop racing a crash can set both bits.
+    if device_data.fault or (rr & _RR_WDT0):
+        if device_data.fault:
+            return (
+                f"crashed ({_fault_name(device_data)} "
+                f"pc=0x{device_data.pc:08x})"
+            )
+        return "crashed (hang)"
+    if rr & _RR_WDT1:
+        return "stopped"
+    if rr & _RR_LOCKUP:
+        return "lockup"
+    if rr == 0 or (rr & _RR_PIN):
+        return "power-on"
+    if rr & _RR_SREQ:
+        return "soft-reset"
+    return decode_reset_reason(rr)
 
 
 def reset_cause_color(device_data) -> str:
-    suspicious = (
-        device_data.fault
-        # watchdog0, lockup, watchdog1
-        or device_data.reset_reason & ((1 << 1) | (1 << 4) | (1 << 25))
-    )
-    return "red" if suspicious else "cyan"
+    if device_data.fault or (
+        device_data.reset_reason & (_RR_WDT0 | _RR_LOCKUP)
+    ):
+        return "red"
+    return "cyan"
 
 
 def generate_status(status_data, devices=[], status_message="found"):
@@ -210,6 +243,74 @@ def generate_status(status_data, devices=[], status_message="found"):
             f"[{reset_cause_color(device_data)}]{format_reset_cause(device_data)}",
         )
     return Group(header, table)
+
+
+def generate_inspect(status_data, devices=[]):
+    """Full per-device detail: every status field plus the raw crash report.
+
+    The status table shows a friendly one-line reset cause; this dumps
+    everything the bot reports - decoded and raw - for post-mortem of a
+    specific robot.
+    """
+    data = {
+        addr: device_data
+        for addr, device_data in status_data.items()
+        if (devices and addr in devices) or (not devices)
+    }
+    if not data:
+        return Group(Text("\nNo matching device\n"))
+
+    panels = []
+    for device_addr, d in sorted(data.items()):
+        table = Table(show_header=False, box=None, pad_edge=False)
+        table.add_column("field", style="bold cyan", no_wrap=True)
+        table.add_column("value")
+
+        table.add_row("Device", device_addr)
+        table.add_row("Type", d.device.name)
+        table.add_row("Status", d.status.name)
+        table.add_row(
+            "Battery",
+            f"[{battery_level_color(d.battery)}]{d.battery / 1000:.2f}V "
+            f"({int(d.battery / 3000 * 100)}%)",
+        )
+        table.add_row("Position", f"({d.pos_x}, {d.pos_y})")
+        if d.last_updated_at:
+            age = max(0.0, time.time() - d.last_updated_at)
+            table.add_row("Last update", f"{age:.1f}s ago")
+
+        table.add_row("", "")
+        table.add_row(
+            "Last reset",
+            f"[{reset_cause_color(d)}]{format_reset_cause(d)}",
+        )
+        table.add_row(
+            "  reset_reason",
+            f"0x{d.reset_reason:08x} ({decode_reset_reason(d.reset_reason)})",
+        )
+        table.add_row(
+            "  fault",
+            f"{_fault_name(d)}"
+            + (" (non-secure)" if d.fault and d.from_ns else "")
+            + (" (secure)" if d.fault and not d.from_ns else ""),
+        )
+        if d.fault:
+            cfsr_bits = decode_cfsr(d.cfsr)
+            sfsr_bits = decode_sfsr(d.sfsr)
+            table.add_row(
+                "  cfsr",
+                f"0x{d.cfsr:08x}" + (f" ({cfsr_bits})" if cfsr_bits else ""),
+            )
+            table.add_row(
+                "  sfsr",
+                f"0x{d.sfsr:08x}" + (f" ({sfsr_bits})" if sfsr_bits else ""),
+            )
+            elf = "app image" if d.from_ns else "bootloader image"
+            table.add_row("  pc", f"0x{d.pc:08x}  (resolve against {elf})")
+            table.add_row("  lr", f"0x{d.lr:08x}")
+        panels.append(table)
+        panels.append(Text(""))
+    return Group(*panels)
 
 
 def print_transfer_status(
@@ -421,6 +522,7 @@ class Controller:
                 pos_y=packet.payload.pos_y,
                 reset_reason=packet.payload.reset_reason,
                 fault=packet.payload.fault,
+                from_ns=packet.payload.from_ns,
                 cfsr=packet.payload.cfsr,
                 sfsr=packet.payload.sfsr,
                 pc=packet.payload.pc,

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -106,11 +106,64 @@ def decode_reset_reason(reset_reason: int) -> str:
     return "+".join(labels)
 
 
+# ARMv8-M Configurable Fault Status Register (CFSR) bits: MMFSR (0-7),
+# BFSR (8-15), UFSR (16-31). Used by the inspect command to spell out the
+# raw fault status the bootloader latched.
+CFSR_FLAGS = {
+    1 << 0: "IACCVIOL",
+    1 << 1: "DACCVIOL",
+    1 << 3: "MUNSTKERR",
+    1 << 4: "MSTKERR",
+    1 << 5: "MLSPERR",
+    1 << 8: "IBUSERR",
+    1 << 9: "PRECISERR",
+    1 << 10: "IMPRECISERR",
+    1 << 11: "UNSTKERR",
+    1 << 12: "STKERR",
+    1 << 13: "LSPERR",
+    1 << 16: "UNDEFINSTR",
+    1 << 17: "INVSTATE",
+    1 << 18: "INVPC",
+    1 << 19: "NOCP",
+    1 << 20: "STKOF",
+    1 << 24: "UNALIGNED",
+    1 << 25: "DIVBYZERO",
+}
+
+# ARMv8-M Secure Fault Status Register (SFSR) bits.
+SFSR_FLAGS = {
+    1 << 0: "INVEP",
+    1 << 1: "INVIS",
+    1 << 2: "INVER",
+    1 << 3: "AUVIOL",
+    1 << 4: "INVTRAN",
+    1 << 5: "LSPERR",
+    1 << 6: "SFARVALID",
+    1 << 7: "LSERR",
+}
+
+
+def _decode_flags(value: int, flags: dict[int, str]) -> str:
+    if value == 0:
+        return ""
+    return "+".join(label for mask, label in flags.items() if value & mask)
+
+
+def decode_cfsr(cfsr: int) -> str:
+    """Decode a CFSR value into its set fault-status flag names."""
+    return _decode_flags(cfsr, CFSR_FLAGS)
+
+
+def decode_sfsr(sfsr: int) -> str:
+    """Decode an SFSR value into its set secure-fault flag names."""
+    return _decode_flags(sfsr, SFSR_FLAGS)
+
+
 # Size of the status payload sent by firmware without crash-report support.
 STATUS_LEGACY_SIZE = 12
 # Size of the crash report appended to status payloads (mirrors
 # ipc_crash_report_t in the swarmit firmware).
-CRASH_REPORT_SIZE = 21
+CRASH_REPORT_SIZE = 22
 
 
 # Requests
@@ -131,6 +184,7 @@ class PayloadStatus(Payload):
             ),
             PayloadFieldMetadata(name="reset_reason", disp="rst", length=4),
             PayloadFieldMetadata(name="fault", disp="fault"),
+            PayloadFieldMetadata(name="from_ns", disp="ns"),
             PayloadFieldMetadata(name="cfsr", disp="cfsr", length=4),
             PayloadFieldMetadata(name="sfsr", disp="sfsr", length=4),
             PayloadFieldMetadata(name="pc", disp="pc", length=4),
@@ -145,6 +199,7 @@ class PayloadStatus(Payload):
     pos_y: int = 0
     reset_reason: int = 0
     fault: int = 0
+    from_ns: int = 0
     cfsr: int = 0
     sfsr: int = 0
     pc: int = 0

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -67,6 +67,52 @@ class PayloadType(IntEnum):
 LH2_CALIB_TAG = 0xCA
 
 
+class FaultType(Enum):
+    """Fault latched by the bootloader before the reset."""
+
+    NoFault = 0
+    HardFault = 1
+    SecureFault = 2
+
+
+# nRF5340 application core RESETREAS flags (bit position -> short label).
+RESET_REASON_FLAGS = {
+    1 << 0: "pin",
+    1 << 1: "watchdog0",
+    1 << 2: "ctrl-ap",
+    1 << 3: "soft-reset",
+    1 << 4: "lockup",
+    1 << 5: "off-wakeup",
+    1 << 6: "lpcomp",
+    1 << 7: "debug-if",
+    1 << 24: "nfc",
+    1 << 25: "watchdog1",
+    1 << 26: "vbus",
+}
+
+
+def decode_reset_reason(reset_reason: int) -> str:
+    """Decode a RESETREAS register value into a short readable string."""
+    if reset_reason == 0:
+        return "power-on"
+    labels = [
+        label
+        for mask, label in RESET_REASON_FLAGS.items()
+        if reset_reason & mask
+    ]
+    unknown = reset_reason & ~sum(RESET_REASON_FLAGS)
+    if unknown:
+        labels.append(f"0x{unknown:08x}")
+    return "+".join(labels)
+
+
+# Size of the status payload sent by firmware without crash-report support.
+STATUS_LEGACY_SIZE = 12
+# Size of the crash report appended to status payloads (mirrors
+# ipc_crash_report_t in the swarmit firmware).
+CRASH_REPORT_SIZE = 21
+
+
 # Requests
 @dataclass
 class PayloadStatus(Payload):
@@ -83,6 +129,12 @@ class PayloadStatus(Payload):
             PayloadFieldMetadata(
                 name="pos_y", disp="pos y", length=4, signed=True
             ),
+            PayloadFieldMetadata(name="reset_reason", disp="rst", length=4),
+            PayloadFieldMetadata(name="fault", disp="fault"),
+            PayloadFieldMetadata(name="cfsr", disp="cfsr", length=4),
+            PayloadFieldMetadata(name="sfsr", disp="sfsr", length=4),
+            PayloadFieldMetadata(name="pc", disp="pc", length=4),
+            PayloadFieldMetadata(name="lr", disp="lr", length=4),
         ]
     )
 
@@ -91,6 +143,20 @@ class PayloadStatus(Payload):
     battery: int = 0
     pos_x: int = 0
     pos_y: int = 0
+    reset_reason: int = 0
+    fault: int = 0
+    cfsr: int = 0
+    sfsr: int = 0
+    pc: int = 0
+    lr: int = 0
+
+    def from_bytes(self, bytes_):
+        # Firmware without crash-report support sends the legacy short
+        # payload; parse it with a zeroed crash report so mixed fleets keep
+        # reporting status during the bootloader rollout.
+        if len(bytes_) == STATUS_LEGACY_SIZE:
+            bytes_ = bytes(bytes_) + bytes(CRASH_REPORT_SIZE)
+        return super().from_bytes(bytes_)
 
 
 @dataclass

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -4,7 +4,9 @@ from swarmit.testbed.protocol import (
     CRASH_REPORT_SIZE,
     STATUS_LEGACY_SIZE,
     PayloadStatus,
+    decode_cfsr,
     decode_reset_reason,
+    decode_sfsr,
 )
 
 
@@ -17,6 +19,7 @@ def test_payload_status_round_trip():
         pos_y=200,
         reset_reason=0x2,  # watchdog0
         fault=2,  # secure fault
+        from_ns=1,
         cfsr=0x100,
         sfsr=0x8,
         pc=0x0001_2345,
@@ -33,6 +36,7 @@ def test_payload_status_round_trip():
     assert parsed.pos_y == 200
     assert parsed.reset_reason == 0x2
     assert parsed.fault == 2
+    assert parsed.from_ns == 1
     assert parsed.cfsr == 0x100
     assert parsed.sfsr == 0x8
     assert parsed.pc == 0x0001_2345
@@ -54,6 +58,7 @@ def test_payload_status_legacy_frame():
     assert parsed.pos_y == 43
     assert parsed.reset_reason == 0
     assert parsed.fault == 0
+    assert parsed.from_ns == 0
     assert parsed.pc == 0
 
 
@@ -77,3 +82,17 @@ def test_payload_status_truncated_frame_raises():
 )
 def test_decode_reset_reason(value, expected):
     assert decode_reset_reason(value) == expected
+
+
+def test_decode_cfsr():
+    assert decode_cfsr(0) == ""
+    assert decode_cfsr(1 << 1) == "DACCVIOL"
+    assert decode_cfsr(1 << 25) == "DIVBYZERO"
+    assert decode_cfsr(1 << 20) == "STKOF"
+
+
+def test_decode_sfsr():
+    assert decode_sfsr(0) == ""
+    # NS write into a secure region -> attribution unit violation
+    assert decode_sfsr(1 << 3) == "AUVIOL"
+    assert decode_sfsr(1 << 0) == "INVEP"

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -1,0 +1,79 @@
+import pytest
+
+from swarmit.testbed.protocol import (
+    CRASH_REPORT_SIZE,
+    STATUS_LEGACY_SIZE,
+    PayloadStatus,
+    decode_reset_reason,
+)
+
+
+def test_payload_status_round_trip():
+    payload = PayloadStatus(
+        device=1,
+        status=2,
+        battery=2800,
+        pos_x=100,
+        pos_y=200,
+        reset_reason=0x2,  # watchdog0
+        fault=2,  # secure fault
+        cfsr=0x100,
+        sfsr=0x8,
+        pc=0x0001_2345,
+        lr=0x0001_2340,
+    )
+    raw = payload.to_bytes()
+    assert len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE
+
+    parsed = PayloadStatus().from_bytes(bytes(raw))
+    assert parsed.device == 1
+    assert parsed.status == 2
+    assert parsed.battery == 2800
+    assert parsed.pos_x == 100
+    assert parsed.pos_y == 200
+    assert parsed.reset_reason == 0x2
+    assert parsed.fault == 2
+    assert parsed.cfsr == 0x100
+    assert parsed.sfsr == 0x8
+    assert parsed.pc == 0x0001_2345
+    assert parsed.lr == 0x0001_2340
+
+
+def test_payload_status_legacy_frame():
+    # Status payload from firmware without crash-report support: 12 bytes,
+    # crash report fields parse as zero.
+    legacy = PayloadStatus(
+        device=1, status=1, battery=2900, pos_x=42, pos_y=43
+    ).to_bytes()[:STATUS_LEGACY_SIZE]
+
+    parsed = PayloadStatus().from_bytes(bytes(legacy))
+    assert parsed.device == 1
+    assert parsed.status == 1
+    assert parsed.battery == 2900
+    assert parsed.pos_x == 42
+    assert parsed.pos_y == 43
+    assert parsed.reset_reason == 0
+    assert parsed.fault == 0
+    assert parsed.pc == 0
+
+
+def test_payload_status_truncated_frame_raises():
+    with pytest.raises(ValueError):
+        PayloadStatus().from_bytes(bytes(5))
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, "power-on"),
+        (1 << 0, "pin"),
+        (1 << 1, "watchdog0"),
+        (1 << 3, "soft-reset"),
+        (1 << 4, "lockup"),
+        ((1 << 1) | (1 << 3), "watchdog0+soft-reset"),
+        (1 << 25, "watchdog1"),
+        (1 << 30, "0x40000000"),
+    ],
+)
+def test_decode_reset_reason(value, expected):
+    assert decode_reset_reason(value) == expected


### PR DESCRIPTION
Devices that crash or hang fall back to the bootloader with zero
observability: the fault handlers only capture registers in Debug builds
and then spin until the watchdog resets the SoC, and the bootloader reads
RESETREAS and clears it without reporting it. With ~50 robots this happens
often enough (see #128) that we need to know which failure class dominates
before attempting fixes.

Approach: the fault handlers now always latch the fault type, CFSR, SFSR,
and the stacked PC/LR into a small struct in the .non_init RAM section, so
the snapshot survives the watchdog reset. On boot the bootloader publishes
RESETREAS plus any valid latch into a crash_report field at the end of
ipc_shared_data, and the network core appends it to the 1 Hz status frame.
The crash report is sent in every status frame on purpose: last-reset
cause is state, not an event, so any observer (edge, cloud, dashboard)
gets it regardless of when it attaches, and the uplink packet count is
unchanged.

The host side turns this into a friendly "Last reset" column - crashed /
stopped / soft-reset / power-on - mapping the raw RESETREAS plus latched
fault onto swarmit semantics (WDT1 is only ever started by the stop
command, so DOG1 reliably reads as "stopped"; a crash racing a stop still
reads as crashed). A new `info` command dumps the full per-device
report: decoded reset reason, CFSR/SFSR fault bits, the faulting PC/LR
with a hint on which image to resolve against, and the raw status packet
as hex for ground-truth debugging.

Non-secure PC recovery: when a non-secure access faults into the secure
handler, the exception frame lives on the non-secure stack, so the
trampoline now branches on EXC_RETURN.S and reads MSP_NS/PSP_NS for a
non-secure background - otherwise the captured PC came back as 0. A
from_ns flag records which security state faulted so the host knows the
PC resolves against the app image rather than the bootloader.

Reviewer notes:
- The latch sets its magic word before reading the stacked frame; if the
  frame is unreadable (stacking fault), the latch stays valid with pc/lr
  zeroed instead of reporting stale values from a previous crash.
- Both ipc.h copies (bootloader and network core) carry the identical
  crash_report struct appended at the end of ipc_shared_data, packed at
  22 bytes, so the writer and reader agree on the layout.
- NSC veneer addresses are unchanged in the rebuilt map, so apps-sandbox
  images and the exported cmse_implib do not need a rebuild.
- The Python parser accepts the legacy 12-byte status payload with a
  zeroed crash report; bootloader updates need J-Link, so mixed fleets
  will exist for a while. Old Python against new firmware also works
  (trailing bytes are ignored).
- The single-core bootloader is untouched; those devices keep sending
  legacy frames.

Validated on the bench: a non-secure write to a secure address shows up
as "crashed (watchdog0 SecureFault pc=0x...)", with the info view
decoding sfsr=0x48 (AUVIOL+SFARVALID), from_ns=1, and a PC that resolves
cleanly into the app image. Full pytest suite passes including new tests
for the extended/legacy status payloads and the RESETREAS/CFSR/SFSR
decoders.