### PR TITLE
fast OTA: block / bitmap-NACK protocol (~9x, 210s -> 24s)

### DIFF
--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -53,12 +53,11 @@ typedef struct __attribute__((packed)) {
     uint32_t chunk_count;
     uint32_t chunk_index;
     uint32_t chunk_size;
-    int32_t  last_chunk_acked;
-    uint32_t block_index;                                 ///< Current block being received (block OTA)
+    int32_t  last_chunk_seen;                             ///< Last chunk index the net core published (-1 = none)
+    uint32_t block_index;                                 ///< Current block being received
     uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
     uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
     uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
-    uint8_t  protocol_version;                            ///< OTA protocol version from OTA_START (>=2 => block, skip per-chunk ack)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -40,6 +40,7 @@ typedef enum {
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
     IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
     IPC_CHAN_LH2_CAPTURE        = 9,    ///< Channel used to trigger a raw LH2 capture (READY mode only)
+    IPC_CHAN_OTA_FINALIZE       = 10,   ///< Channel used to verify the whole image SHA256 (block OTA)
 } ipc_channels_t;
 
 typedef struct __attribute__((packed)) {
@@ -53,6 +54,10 @@ typedef struct __attribute__((packed)) {
     uint32_t chunk_index;
     uint32_t chunk_size;
     int32_t  last_chunk_acked;
+    uint32_t block_index;                                 ///< Current block being received (block OTA)
+    uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
+    uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
+    uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -58,6 +58,7 @@ typedef struct __attribute__((packed)) {
     uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
     uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
     uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
+    uint8_t  protocol_version;                            ///< OTA protocol version from OTA_START (>=2 => block, skip per-chunk ack)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -15,6 +15,7 @@
 
 #include <nrf.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "localization.h"
 #include "protocol.h"
@@ -48,7 +49,9 @@ typedef struct __attribute__((packed)) {
     uint8_t data[INT8_MAX];
 } ipc_log_data_t;
 
-typedef struct __attribute__((packed)) {
+/// Shared memory only, never serialized: unpacked so the compiler keeps its
+/// size a multiple of 4 and the members after it stay word-aligned.
+typedef struct {
     uint32_t image_size;
     uint32_t chunk_count;
     uint32_t chunk_index;
@@ -103,6 +106,24 @@ typedef struct __attribute__((packed,aligned(8))) {
     ipc_lh2_calibration_t  lh2_calibration;     ///< LH2 calibration data
     ipc_crash_report_t      crash_report;       ///< Cause of the most recent reset
 } ipc_shared_data_t;
+
+// ipc_shared_data_t is packed, so every member's offset is the running sum of
+// the ones before it. The members after `ota` hold 32-bit values that the
+// secure core reads and writes with word accesses while SCB->CCR.UNALIGN_TRP
+// is set, so a member whose size is not a multiple of 4 shifts them off
+// alignment and those accesses take a HardFault instead of faulting loudly at
+// the point of the mistake. Assert the alignment here so a size change is
+// caught at compile time.
+_Static_assert(sizeof(ipc_ota_data_t) % 4 == 0,
+               "ipc_ota_data_t size must be a multiple of 4");
+_Static_assert(offsetof(ipc_shared_data_t, target_position) % 4 == 0,
+               "target_position must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, current_position) % 4 == 0,
+               "current_position must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, lh2_calibration) % 4 == 0,
+               "lh2_calibration must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, crash_report) % 4 == 0,
+               "crash_report must be 4-byte aligned");
 
 void mutex_lock(void);
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -52,6 +52,7 @@ extern volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_s
 
 typedef struct {
     uint8_t         notification_buffer[255]  __attribute__((aligned));
+    uint8_t         chunk_copy[SWRMT_OTA_CHUNK_SIZE];  ///< snapshot of the shared chunk, taken under mutex before the slow flash write
     uint32_t        base_addr;
     bool            ota_start_request;
     bool            ota_require_erase;
@@ -437,39 +438,51 @@ int main(void) {
         if (_bootloader_vars.ota_chunk_request) {
             _bootloader_vars.ota_chunk_request = false;
 
-            if (ipc_shared_data.ota.last_chunk_acked != (int32_t)ipc_shared_data.ota.chunk_index) {
-                // Write chunk to flash
-                uint32_t addr = _bootloader_vars.base_addr + ipc_shared_data.ota.chunk_index * SWRMT_OTA_CHUNK_SIZE;
-                printf("Writing chunk %d/%d at address %p\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_count - 1, (uint32_t *)addr);
-                nvmc_write((uint32_t *)addr, (void *)ipc_shared_data.ota.chunk, ipc_shared_data.ota.chunk_size);
-                _bootloader_vars.ota_require_erase = true;
-            }
-
-            // Block-OTA bitmap: reset the mask when the block advances, then
-            // mark this chunk received. Runs for duplicates too (a re-sent chunk
-            // still means the bot has it); the net core reads this to answer
-            // block-report requests. Reset keys on block change, not on chunk
-            // index 0, so a repair re-send of another bot's chunk 0 does not
-            // wipe this bot's in-progress block.
-            uint32_t blk = ipc_shared_data.ota.chunk_index / SWRMT_OTA_BLOCK_SIZE;
+            // Snapshot index/size and the chunk data under the mutex (so we never
+            // read a torn buffer while the net core publishes the next chunk),
+            // advance the block window, and dedup on the mask ("already in
+            // flash") - so a retransmit is never written twice (nWRITE=2 safety).
+            // Reset the mask on block change, not on chunk index 0, so a repair
+            // re-send of another bot's chunk 0 does not wipe an in-progress block.
             mutex_lock();
+            uint32_t index = ipc_shared_data.ota.chunk_index;
+            uint32_t size  = ipc_shared_data.ota.chunk_size;
+            uint32_t blk   = index / SWRMT_OTA_BLOCK_SIZE;
+            uint32_t bit   = 1u << (index % SWRMT_OTA_BLOCK_SIZE);
             if (blk != ipc_shared_data.ota.block_index) {
                 ipc_shared_data.ota.block_index = blk;
                 ipc_shared_data.ota.received_mask = 0;
             }
-            ipc_shared_data.ota.received_mask |= (1u << (ipc_shared_data.ota.chunk_index % SWRMT_OTA_BLOCK_SIZE));
+            bool need_write = (ipc_shared_data.ota.received_mask & bit) == 0;
+            if (need_write) {
+                memcpy(_bootloader_vars.chunk_copy, (void *)ipc_shared_data.ota.chunk, size);
+            }
             mutex_unlock();
 
-            // Notify chunk has been written
-            size_t length = 0;
-            _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_CHUNK_ACK;
-            memcpy(_bootloader_vars.notification_buffer + length, (void *)&ipc_shared_data.ota.chunk_index, sizeof(uint32_t));
-            length += sizeof(uint32_t);
-            ipc_shared_data.ota.last_chunk_acked = ipc_shared_data.ota.chunk_index;
-            mari_node_tx(_bootloader_vars.notification_buffer, length);
+            if (need_write) {
+                uint32_t addr = _bootloader_vars.base_addr + index * SWRMT_OTA_CHUNK_SIZE;
+                nvmc_write((uint32_t *)addr, (void *)_bootloader_vars.chunk_copy, size);
+                _bootloader_vars.ota_require_erase = true;
+                mutex_lock();
+                ipc_shared_data.ota.received_mask |= bit;
+                mutex_unlock();
+            }
+            ipc_shared_data.ota.last_chunk_acked = (int32_t)index;
 
-            // If last chunk, finalize computed hash, set back to ready state
-            if (ipc_shared_data.ota.chunk_index == ipc_shared_data.ota.chunk_count - 1) {
+            // Per-chunk ack ONLY for the legacy per-chunk protocol. In block mode
+            // (version >= 2) the controller tracks delivery via block reports;
+            // an uplink ack per chunk would throttle the transfer to the node's
+            // single uplink cell per slotframe.
+            if (ipc_shared_data.ota.protocol_version < SWRMT_OTA_PROTOCOL_VERSION) {
+                size_t length = 0;
+                _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_CHUNK_ACK;
+                memcpy(_bootloader_vars.notification_buffer + length, (void *)&index, sizeof(uint32_t));
+                length += sizeof(uint32_t);
+                mari_node_tx(_bootloader_vars.notification_buffer, length);
+            }
+
+            // If last chunk, set back to ready state
+            if (index == ipc_shared_data.ota.chunk_count - 1) {
                 ipc_shared_data.status = SWRMT_APPLICATION_READY;
             }
         }

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -467,19 +467,12 @@ int main(void) {
                 ipc_shared_data.ota.received_mask |= bit;
                 mutex_unlock();
             }
-            ipc_shared_data.ota.last_chunk_acked = (int32_t)index;
+            ipc_shared_data.ota.last_chunk_seen = (int32_t)index;
 
-            // Per-chunk ack ONLY for the legacy per-chunk protocol. In block mode
-            // (version >= 2) the controller tracks delivery via block reports;
-            // an uplink ack per chunk would throttle the transfer to the node's
-            // single uplink cell per slotframe.
-            if (ipc_shared_data.ota.protocol_version < SWRMT_OTA_PROTOCOL_VERSION) {
-                size_t length = 0;
-                _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_CHUNK_ACK;
-                memcpy(_bootloader_vars.notification_buffer + length, (void *)&index, sizeof(uint32_t));
-                length += sizeof(uint32_t);
-                mari_node_tx(_bootloader_vars.notification_buffer, length);
-            }
+            // No per-chunk ack. The controller tracks delivery with one block
+            // report per block instead. Each node owns a single uplink cell per
+            // slotframe, so acking every chunk would throttle the whole
+            // transfer down to that rate.
 
             // If last chunk, set back to ready state
             if (index == ipc_shared_data.ota.chunk_count - 1) {

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -19,6 +19,7 @@
 #include "ipc.h"
 #include "nvmc.h"
 #include "protocol.h"
+#include "sha256.h"
 #include "mari.h"
 #include "tz.h"
 
@@ -55,6 +56,7 @@ typedef struct {
     bool            ota_start_request;
     bool            ota_require_erase;
     bool            ota_chunk_request;
+    bool            ota_finalize_request;
     bool            lh2_calibration_ready;
     bool            lh2_capture_request;
     bool            lh2_capturing;
@@ -263,6 +265,7 @@ int main(void) {
                             1 << IPC_CHAN_RADIO_RX |
                             1 << IPC_CHAN_OTA_START |
                             1 << IPC_CHAN_OTA_CHUNK |
+                            1 << IPC_CHAN_OTA_FINALIZE |
                             1 << IPC_CHAN_APPLICATION_START |
                             1 << IPC_CHAN_SOC_RESET |
                             1 << IPC_CHAN_CALIBRATION_DATA |
@@ -276,6 +279,7 @@ int main(void) {
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_SOC_RESET]          = 1 << IPC_CHAN_SOC_RESET;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_START]          = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_CHUNK]          = 1 << IPC_CHAN_OTA_CHUNK;
+    NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_OTA_FINALIZE]       = 1 << IPC_CHAN_OTA_FINALIZE;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_CALIBRATION_DATA]   = 1 << IPC_CHAN_CALIBRATION_DATA;
     NRF_IPC_S->RECEIVE_CNF[IPC_CHAN_LH2_CAPTURE]        = 1 << IPC_CHAN_LH2_CAPTURE;
     NVIC_EnableIRQ(IPC_IRQn);
@@ -422,9 +426,11 @@ int main(void) {
                 _bootloader_vars.ota_require_erase = false;
             }
 
-            // Notify erase is done
+            // Notify erase is done. Append the OTA protocol version so the
+            // controller knows this bootloader speaks the block/bitmap path.
             size_t length = 0;
             _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_START_ACK;
+            _bootloader_vars.notification_buffer[length++] = SWRMT_OTA_PROTOCOL_VERSION;
             mari_node_tx(_bootloader_vars.notification_buffer, length);
         }
 
@@ -439,6 +445,21 @@ int main(void) {
                 _bootloader_vars.ota_require_erase = true;
             }
 
+            // Block-OTA bitmap: reset the mask when the block advances, then
+            // mark this chunk received. Runs for duplicates too (a re-sent chunk
+            // still means the bot has it); the net core reads this to answer
+            // block-report requests. Reset keys on block change, not on chunk
+            // index 0, so a repair re-send of another bot's chunk 0 does not
+            // wipe this bot's in-progress block.
+            uint32_t blk = ipc_shared_data.ota.chunk_index / SWRMT_OTA_BLOCK_SIZE;
+            mutex_lock();
+            if (blk != ipc_shared_data.ota.block_index) {
+                ipc_shared_data.ota.block_index = blk;
+                ipc_shared_data.ota.received_mask = 0;
+            }
+            ipc_shared_data.ota.received_mask |= (1u << (ipc_shared_data.ota.chunk_index % SWRMT_OTA_BLOCK_SIZE));
+            mutex_unlock();
+
             // Notify chunk has been written
             size_t length = 0;
             _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_CHUNK_ACK;
@@ -451,6 +472,27 @@ int main(void) {
             if (ipc_shared_data.ota.chunk_index == ipc_shared_data.ota.chunk_count - 1) {
                 ipc_shared_data.status = SWRMT_APPLICATION_READY;
             }
+        }
+
+        if (_bootloader_vars.ota_finalize_request) {
+            _bootloader_vars.ota_finalize_request = false;
+            // Whole-image integrity check: hash the written flash and compare
+            // with the controller's expected SHA256. The app core is the only
+            // core that can read this flash, so the check runs here and the
+            // result is sent back directly (mirroring the chunk-ack TX path).
+            crypto_sha256_ctx_t ctx;
+            uint8_t             digest[SWRMT_OTA_SHA256_LENGTH];
+            crypto_sha256_init(&ctx);
+            crypto_sha256_update(&ctx, (const uint8_t *)_bootloader_vars.base_addr, ipc_shared_data.ota.image_size);
+            crypto_sha256(&ctx, digest);
+            uint8_t ok = (memcmp(digest, (const void *)ipc_shared_data.ota.finalize_expected, SWRMT_OTA_SHA256_LENGTH) == 0) ? 1 : 0;
+            ipc_shared_data.ota.finalize_ok = ok;
+            printf("OTA finalize: image SHA256 %s\n", ok ? "OK" : "MISMATCH");
+
+            size_t length = 0;
+            _bootloader_vars.notification_buffer[length++] = SWRMT_MSG_OTA_FINALIZE_RESP;
+            _bootloader_vars.notification_buffer[length++] = ok;
+            mari_node_tx(_bootloader_vars.notification_buffer, length);
         }
 
         if (_bootloader_vars.start_application) {
@@ -539,6 +581,11 @@ void IPC_IRQHandler(void) {
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_OTA_CHUNK]) {
         NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_OTA_CHUNK] = 0;
         _bootloader_vars.ota_chunk_request = true;
+    }
+
+    if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_OTA_FINALIZE]) {
+        NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_OTA_FINALIZE] = 0;
+        _bootloader_vars.ota_finalize_request = true;
     }
 
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_APPLICATION_START]) {

--- a/device/bootloader/Source/protocol.h
+++ b/device/bootloader/Source/protocol.h
@@ -27,11 +27,11 @@
 #define SWRMT_OTA_CHUNK_SIZE        (128U)
 #define SWRMT_OTA_SHA256_LENGTH     (32U)
 
-/// Block-OTA (fast OTA) parameters. W = 22 matches the 22 downlink slots per
-/// Mari "huge" slotframe; the received bitmap is a uint32_t so W may grow to 32
-/// without a wire change. The protocol version is echoed in OTA_START_ACK so the
-/// controller knows the bootloader speaks the block/bitmap path.
-#define SWRMT_OTA_BLOCK_SIZE        (22U)
+/// Block-OTA (fast OTA) parameters. W = 32 is the largest block the uint32_t
+/// received bitmap holds; bigger blocks mean fewer report rounds. Must match the
+/// controller's BLOCK_SIZE. The protocol version is echoed in OTA_START_ACK so
+/// the controller knows the bootloader speaks the block/bitmap path.
+#define SWRMT_OTA_BLOCK_SIZE        (32U)
 #define SWRMT_OTA_PROTOCOL_VERSION  (2U)
 
 /// First byte of a raw LH2 capture sample carried inside a LOG_EVENT payload.

--- a/device/bootloader/Source/protocol.h
+++ b/device/bootloader/Source/protocol.h
@@ -25,6 +25,14 @@
 
 #define SWRMT_PREAMBLE_LENGTH       (8U)
 #define SWRMT_OTA_CHUNK_SIZE        (128U)
+#define SWRMT_OTA_SHA256_LENGTH     (32U)
+
+/// Block-OTA (fast OTA) parameters. W = 22 matches the 22 downlink slots per
+/// Mari "huge" slotframe; the received bitmap is a uint32_t so W may grow to 32
+/// without a wire change. The protocol version is echoed in OTA_START_ACK so the
+/// controller knows the bootloader speaks the block/bitmap path.
+#define SWRMT_OTA_BLOCK_SIZE        (22U)
+#define SWRMT_OTA_PROTOCOL_VERSION  (2U)
 
 /// First byte of a raw LH2 capture sample carried inside a LOG_EVENT payload.
 /// Lets the host tell a calibration sample apart from a regular text log line.
@@ -35,6 +43,25 @@ typedef struct __attribute__((packed)) {
     uint8_t  chunk_size;                        ///< Size of the chunk
     uint8_t  chunk[SWRMT_OTA_CHUNK_SIZE];       ///< Bytes array of the firmware chunk
 } swrmt_ota_chunk_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t block_index;                       ///< Block the controller is asking about
+    uint8_t  block_size;                        ///< Chunks per block (W)
+} swrmt_ota_block_report_req_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t block_index;                       ///< Block the device currently holds
+    uint32_t received_mask;                     ///< Bit i set: chunk block_index*W+i written
+    uint8_t  status;                            ///< Reserved (0)
+} swrmt_ota_block_report_resp_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  sha[SWRMT_OTA_SHA256_LENGTH];      ///< Expected SHA256 of the whole image
+} swrmt_ota_finalize_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  ok;                                ///< 1 if the image SHA256 matched
+} swrmt_ota_finalize_resp_pkt_t;
 
 typedef enum {
     SWRMT_APPLICATION_READY = 0,
@@ -55,6 +82,10 @@ typedef enum {
     SWRMT_MSG_OTA_CHUNK_ACK = 0x87,
     SWRMT_MSG_GPIO_EVENT = 0x88,
     SWRMT_MSG_LOG_EVENT = 0x89,
+    SWRMT_MSG_OTA_BLOCK_REPORT_REQ = 0x8A,   ///< host -> device: request received bitmap
+    SWRMT_MSG_OTA_BLOCK_REPORT_RESP = 0x8B,  ///< device -> host: received bitmap for a block
+    SWRMT_MSG_OTA_FINALIZE = 0x8C,           ///< host -> device: verify whole-image SHA256
+    SWRMT_MSG_OTA_FINALIZE_RESP = 0x8D,      ///< device -> host: image SHA256 match result
 } swrmt_message_type_t;
 
 /// Application type

--- a/device/bootloader/Source/protocol.h
+++ b/device/bootloader/Source/protocol.h
@@ -79,7 +79,7 @@ typedef enum {
     SWRMT_MSG_OTA_START = 0x84,
     SWRMT_MSG_OTA_CHUNK = 0x85,
     SWRMT_MSG_OTA_START_ACK = 0x86,
-    SWRMT_MSG_OTA_CHUNK_ACK = 0x87,
+    SWRMT_MSG_OTA_CHUNK_ACK = 0x87,          ///< retired with the per-chunk OTA path; id kept reserved
     SWRMT_MSG_GPIO_EVENT = 0x88,
     SWRMT_MSG_LOG_EVENT = 0x89,
     SWRMT_MSG_OTA_BLOCK_REPORT_REQ = 0x8A,   ///< host -> device: request received bitmap

--- a/device/bootloader/bootloader-app.emProject
+++ b/device/bootloader/bootloader-app.emProject
@@ -3,7 +3,7 @@
   <project Name="bootloader">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_dotbot_lh2(bsp);00bsp_gpio(bsp);00bsp_saadc(bsp);00bsp_timer(bsp)"
+      project_dependencies="00bsp_dotbot_lh2(bsp);00bsp_gpio(bsp);00bsp_saadc(bsp);00bsp_timer(bsp);00crypto_sha256(crypto)"
       project_directory=""
       project_type="Executable" />
     <configuration Name="Release" gcc_optimization_level="Level 0" />

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -43,6 +43,7 @@ typedef enum {
     IPC_CHAN_OTA_CHUNK          = 7,    ///< Channel used for writing a non secure image chunk
     IPC_CHAN_CALIBRATION_DATA   = 8,    ///< Channel used for sending calibration data
     IPC_CHAN_LH2_CAPTURE        = 9,    ///< Channel used to trigger a raw LH2 capture (READY mode only)
+    IPC_CHAN_OTA_FINALIZE       = 10,   ///< Channel used to verify the whole image SHA256 (block OTA)
 } ipc_channels_t;
 
 typedef struct {
@@ -65,6 +66,10 @@ typedef struct __attribute__((packed)) {
     uint32_t chunk_index;
     uint32_t chunk_size;
     int32_t  last_chunk_acked;
+    uint32_t block_index;                                 ///< Current block being received (block OTA)
+    uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
+    uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
+    uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -70,6 +70,7 @@ typedef struct __attribute__((packed)) {
     uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
     uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
     uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
+    uint8_t  protocol_version;                            ///< OTA protocol version from OTA_START (>=2 => block, skip per-chunk ack)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -65,12 +65,11 @@ typedef struct __attribute__((packed)) {
     uint32_t chunk_count;
     uint32_t chunk_index;
     uint32_t chunk_size;
-    int32_t  last_chunk_acked;
-    uint32_t block_index;                                 ///< Current block being received (block OTA)
+    int32_t  last_chunk_seen;                             ///< Last chunk index the net core published (-1 = none)
+    uint32_t block_index;                                 ///< Current block being received
     uint32_t received_mask;                               ///< Bit i set: chunk block_index*W+i written to flash
     uint8_t  finalize_expected[SWRMT_OTA_SHA256_LENGTH];  ///< Expected whole-image SHA256 (FINALIZE)
     uint8_t  finalize_ok;                                 ///< FINALIZE result (1 = image SHA256 matched)
-    uint8_t  protocol_version;                            ///< OTA protocol version from OTA_START (>=2 => block, skip per-chunk ack)
     uint8_t chunk[INT8_MAX + 1];
 } ipc_ota_data_t;
 

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -15,6 +15,7 @@
 
 #include <nrf.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "protocol.h"
 
@@ -60,7 +61,9 @@ typedef struct __attribute__((packed)) {
     uint8_t data[INT8_MAX];
 } ipc_log_data_t;
 
-typedef struct __attribute__((packed)) {
+/// Shared memory only, never serialized: unpacked so the compiler keeps its
+/// size a multiple of 4 and the members after it stay word-aligned.
+typedef struct {
     uint32_t image_size;
     uint32_t chunk_count;
     uint32_t chunk_index;
@@ -113,6 +116,23 @@ typedef struct __attribute__((packed)) {
     ipc_lh2_calibration_t    lh2_calibration;     ///< LH2 calibration data
     ipc_crash_report_t      crash_report;       ///< Cause of the most recent reset
 } ipc_shared_data_t;
+
+// This layout must stay identical to the app core's copy in
+// device/bootloader/Source/ipc.h. ipc_shared_data_t is packed, so every
+// member's offset is the running sum of the ones before it, and the members
+// after `ota` hold 32-bit values the secure app core reads with word accesses
+// while SCB->CCR.UNALIGN_TRP is set. A member whose size is not a multiple of
+// 4 shifts them off alignment and those accesses take a HardFault there.
+_Static_assert(sizeof(ipc_ota_data_t) % 4 == 0,
+               "ipc_ota_data_t size must be a multiple of 4");
+_Static_assert(offsetof(ipc_shared_data_t, target_position) % 4 == 0,
+               "target_position must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, current_position) % 4 == 0,
+               "current_position must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, lh2_calibration) % 4 == 0,
+               "lh2_calibration must be 4-byte aligned");
+_Static_assert(offsetof(ipc_shared_data_t, crash_report) % 4 == 0,
+               "crash_report must be 4-byte aligned");
 
 /**
  * @brief Lock the mutex, blocks until the mutex is locked

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -313,6 +313,10 @@ int main(void) {
                     mutex_lock();
                     ipc_shared_data.ota.image_size = pkt->image_size;
                     ipc_shared_data.ota.chunk_count = pkt->chunk_count;
+                    // Protocol version tells the bootloader block (>=2) vs legacy:
+                    // in block mode it must NOT send a per-chunk ack (that uplink
+                    // frame per chunk throttles the transfer to the uplink rate).
+                    ipc_shared_data.ota.protocol_version = pkt->version;
                     // Reset the block-OTA bitmap state for the new image.
                     ipc_shared_data.ota.block_index = 0;
                     ipc_shared_data.ota.received_mask = 0;
@@ -328,39 +332,38 @@ int main(void) {
                     }
 
                     const swrmt_ota_chunk_pkt_t *pkt = (const swrmt_ota_chunk_pkt_t *)req->data;
-                    ipc_shared_data.ota.chunk_index = pkt->index;
+                    uint32_t index = pkt->index;
 
                     // Check chunk index is valid
-                    if (ipc_shared_data.ota.chunk_index >= ipc_shared_data.ota.chunk_count) {
-                        printf("Invalid chunk index %u\n", ipc_shared_data.ota.chunk_index);
+                    if (index >= ipc_shared_data.ota.chunk_count) {
                         break;
                     }
 
-                    // Only check for matching sha if chunk was not already acked
-                    if (ipc_shared_data.ota.last_chunk_acked != (int32_t)ipc_shared_data.ota.chunk_index) {
-                        printf("Verify SHA for chunk %u: ", ipc_shared_data.ota.chunk_index);
-                        ipc_shared_data.ota.chunk_size = pkt->chunk_size;
-                        mutex_lock();
-                        memcpy((uint8_t *)ipc_shared_data.ota.chunk, pkt->chunk, pkt->chunk_size);
-                        mutex_unlock();
-
-                        // Copy expected hash
-                        memcpy(_app_vars.expected_hash, pkt->sha, SWRMT_OTA_SHA256_LENGTH);
-
-                        // Compute and compare the chunk hash with the received one
+                    // Only verify + publish if the chunk was not already handled.
+                    if (ipc_shared_data.ota.last_chunk_acked != (int32_t)index) {
+                        // Verify the chunk SHA on the wire buffer (our own req
+                        // buffer) BEFORE publishing it to the shared IPC buffer -
+                        // no lock needed for the verify.
                         crypto_sha256_init(&_app_vars.sha256_ctx);
-                        mutex_lock();
-                        crypto_sha256_update(&_app_vars.sha256_ctx, (const uint8_t *)ipc_shared_data.ota.chunk, ipc_shared_data.ota.chunk_size);
-                        mutex_unlock();
+                        crypto_sha256_update(&_app_vars.sha256_ctx, (const uint8_t *)pkt->chunk, pkt->chunk_size);
                         crypto_sha256(&_app_vars.sha256_ctx, _app_vars.computed_hash);
-
-                        if (memcmp(_app_vars.computed_hash, _app_vars.expected_hash, 8) != 0) {
-                            puts("Failed");
+                        if (memcmp(_app_vars.computed_hash, pkt->sha, 8) != 0) {
                             break;
                         }
-                        puts("OK");
+                        // Publish index + size + data together under the mutex so
+                        // the bootloader can never read a torn chunk.
+                        mutex_lock();
+                        ipc_shared_data.ota.chunk_index = index;
+                        ipc_shared_data.ota.chunk_size = pkt->chunk_size;
+                        memcpy((uint8_t *)ipc_shared_data.ota.chunk, pkt->chunk, pkt->chunk_size);
+                        mutex_unlock();
+                    } else {
+                        // Duplicate of the last chunk: republish the index so the
+                        // bootloader can re-set the mask bit (idempotent).
+                        mutex_lock();
+                        ipc_shared_data.ota.chunk_index = index;
+                        mutex_unlock();
                     }
-                    printf("Process OTA chunk request (index: %u, size: %u)\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_size);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_CHUNK] = 1;
                 } break;
                 case SWRMT_MSG_OTA_BLOCK_REPORT_REQ:

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -99,7 +99,8 @@ static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length
         return;
     }
 
-    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_LH2_CALIBRATION) || (packet_type == SWRMT_MSG_LH2_CAPTURE)) {
+    if (((packet_type >= SWRMT_MSG_STATUS) && (packet_type <= SWRMT_MSG_OTA_CHUNK)) || (packet_type == SWRMT_MSG_LH2_CALIBRATION) || (packet_type == SWRMT_MSG_LH2_CAPTURE) ||
+        (packet_type == SWRMT_MSG_OTA_BLOCK_REPORT_REQ) || (packet_type == SWRMT_MSG_OTA_FINALIZE)) {
         _app_vars.req_received = true;
         return;
     }
@@ -226,6 +227,7 @@ int main(void) {
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_SOC_RESET]         = 1 << IPC_CHAN_SOC_RESET;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_START]         = 1 << IPC_CHAN_OTA_START;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_CHUNK]         = 1 << IPC_CHAN_OTA_CHUNK;
+    NRF_IPC_NS->SEND_CNF[IPC_CHAN_OTA_FINALIZE]      = 1 << IPC_CHAN_OTA_FINALIZE;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_CALIBRATION_DATA]  = 1 << IPC_CHAN_CALIBRATION_DATA;
     NRF_IPC_NS->SEND_CNF[IPC_CHAN_LH2_CAPTURE]       = 1 << IPC_CHAN_LH2_CAPTURE;
     NRF_IPC_NS->RECEIVE_CNF[IPC_CHAN_REQ]            = 1 << IPC_CHAN_REQ;
@@ -311,6 +313,10 @@ int main(void) {
                     mutex_lock();
                     ipc_shared_data.ota.image_size = pkt->image_size;
                     ipc_shared_data.ota.chunk_count = pkt->chunk_count;
+                    // Reset the block-OTA bitmap state for the new image.
+                    ipc_shared_data.ota.block_index = 0;
+                    ipc_shared_data.ota.received_mask = 0;
+                    ipc_shared_data.ota.finalize_ok = 0;
                     mutex_unlock();
                     printf("OTA Start request received (size: %u, chunks: %u)\n", ipc_shared_data.ota.image_size, ipc_shared_data.ota.chunk_count);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_START] = 1;
@@ -356,6 +362,43 @@ int main(void) {
                     }
                     printf("Process OTA chunk request (index: %u, size: %u)\n", ipc_shared_data.ota.chunk_index, ipc_shared_data.ota.chunk_size);
                     NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_CHUNK] = 1;
+                } break;
+                case SWRMT_MSG_OTA_BLOCK_REPORT_REQ:
+                {
+                    // Reply with the received-chunk bitmap for the block this
+                    // bot currently holds. The bootloader owns the bitmap (it
+                    // sets bits as it writes flash); the net core just reads the
+                    // shared copy and answers in the bot's own uplink slot, no
+                    // IPC round trip. A bot that has not started the requested
+                    // block reports an earlier block_index, which the controller
+                    // reads as "needs the whole block".
+                    size_t length = 0;
+                    _app_vars.notification_buffer[length++] = SWRMT_MSG_OTA_BLOCK_REPORT_RESP;
+                    mutex_lock();
+                    uint32_t block_index = ipc_shared_data.ota.block_index;
+                    uint32_t received_mask = ipc_shared_data.ota.received_mask;
+                    mutex_unlock();
+                    memcpy(&_app_vars.notification_buffer[length], &block_index, sizeof(uint32_t));
+                    length += sizeof(uint32_t);
+                    memcpy(&_app_vars.notification_buffer[length], &received_mask, sizeof(uint32_t));
+                    length += sizeof(uint32_t);
+                    _app_vars.notification_buffer[length++] = 0;  // status (reserved)
+                    mari_node_tx_payload(_app_vars.notification_buffer, length, &SWARMIT_TX_DEFAULT);
+                } break;
+                case SWRMT_MSG_OTA_FINALIZE:
+                {
+                    if (ipc_shared_data.status != SWRMT_APPLICATION_PROGRAMMING && ipc_shared_data.status != SWRMT_APPLICATION_READY) {
+                        break;
+                    }
+                    // Hand the expected whole-image SHA256 to the app core; it
+                    // reads back its own flash, compares, and sends the
+                    // FINALIZE_RESP itself (it owns the flash and the mari TX
+                    // shim, mirroring the chunk-ack path).
+                    const swrmt_ota_finalize_pkt_t *pkt = (const swrmt_ota_finalize_pkt_t *)req->data;
+                    mutex_lock();
+                    memcpy((uint8_t *)ipc_shared_data.ota.finalize_expected, pkt->sha, SWRMT_OTA_SHA256_LENGTH);
+                    mutex_unlock();
+                    NRF_IPC_NS->TASKS_SEND[IPC_CHAN_OTA_FINALIZE] = 1;
                 } break;
                 case SWRMT_MSG_LH2_CALIBRATION:
                 {

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -57,12 +57,10 @@ typedef struct {
     bool        ipc_log_received;
     uint8_t     gpio_event_idx;
     crypto_sha256_ctx_t sha256_ctx;
-    uint8_t     expected_hash[SWRMT_OTA_SHA256_LENGTH];
     uint8_t     computed_hash[SWRMT_OTA_SHA256_LENGTH];
     uint64_t    device_id;
     uint16_t    mari_net_id;
     bool        mari_initialized;
-    int32_t     last_chunk_acked;
     uint32_t    metrics_rx_counter;
     uint32_t    metrics_tx_counter;
     bool        metrics_received;
@@ -306,18 +304,17 @@ int main(void) {
                     if (ipc_shared_data.status != SWRMT_APPLICATION_READY && ipc_shared_data.status != SWRMT_APPLICATION_PROGRAMMING) {
                         break;
                     }
-                    ipc_shared_data.ota.last_chunk_acked = -1;
+                    ipc_shared_data.ota.last_chunk_seen = -1;
                     ipc_shared_data.status = SWRMT_APPLICATION_PROGRAMMING;
                     const swrmt_ota_start_pkt_t *pkt = (const swrmt_ota_start_pkt_t *)req->data;
                     // Erase the corresponding flash pages.
                     mutex_lock();
                     ipc_shared_data.ota.image_size = pkt->image_size;
                     ipc_shared_data.ota.chunk_count = pkt->chunk_count;
-                    // Protocol version tells the bootloader block (>=2) vs legacy:
-                    // in block mode it must NOT send a per-chunk ack (that uplink
-                    // frame per chunk throttles the transfer to the uplink rate).
-                    ipc_shared_data.ota.protocol_version = pkt->version;
-                    // Reset the block-OTA bitmap state for the new image.
+                    // pkt->version is not stored: this bootloader only speaks the
+                    // block protocol. It still echoes SWRMT_OTA_PROTOCOL_VERSION in
+                    // its START_ACK, which is what the controller checks.
+                    // Reset the block bitmap state for the new image.
                     ipc_shared_data.ota.block_index = 0;
                     ipc_shared_data.ota.received_mask = 0;
                     ipc_shared_data.ota.finalize_ok = 0;
@@ -339,8 +336,15 @@ int main(void) {
                         break;
                     }
 
+                    // chunk_size comes off the radio and bounds two memcpy calls
+                    // (into the shared IPC buffer here, out of it in the
+                    // bootloader), so bound it before either one runs.
+                    if (pkt->chunk_size > SWRMT_OTA_CHUNK_SIZE) {
+                        break;
+                    }
+
                     // Only verify + publish if the chunk was not already handled.
-                    if (ipc_shared_data.ota.last_chunk_acked != (int32_t)index) {
+                    if (ipc_shared_data.ota.last_chunk_seen != (int32_t)index) {
                         // Verify the chunk SHA on the wire buffer (our own req
                         // buffer) BEFORE publishing it to the shared IPC buffer -
                         // no lock needed for the verify.

--- a/device/network_core/Source/main.c
+++ b/device/network_core/Source/main.c
@@ -92,8 +92,10 @@ static void _handle_packet(uint64_t dst_address, uint8_t *packet, uint8_t length
     uint8_t *ptr = _app_vars.req_buffer;
     uint8_t packet_type = (uint8_t)*ptr++;
 
-    if (length == sizeof(mr_metrics_payload_t) && packet_type == MARI_PAYLOAD_TYPE_METRICS_PROBE) {
-        _app_vars.metrics_received = true;
+    if (packet_type == MARI_PAYLOAD_TYPE_METRICS_PROBE) {
+        if (length >= sizeof(mr_metrics_payload_t)) {
+            _app_vars.metrics_received = true;
+        }
         return;
     }
 

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -12,11 +12,11 @@
 #define SWRMT_OTA_CHUNK_SIZE        (128U)
 #define SWRMT_OTA_SHA256_LENGTH     (32U)
 
-/// Block-OTA (fast OTA) parameters. W = 22 matches the 22 downlink slots per
-/// Mari "huge" slotframe; the received bitmap is a uint32_t so W may grow to 32
-/// without a wire change. The protocol version is echoed in OTA_START_ACK so the
-/// controller knows the bootloader speaks the block/bitmap path.
-#define SWRMT_OTA_BLOCK_SIZE        (22U)
+/// Block-OTA (fast OTA) parameters. W = 32 is the largest block the uint32_t
+/// received bitmap holds; bigger blocks mean fewer report rounds. Must match the
+/// controller's BLOCK_SIZE. The protocol version is echoed in OTA_START_ACK so
+/// the controller knows the bootloader speaks the block/bitmap path.
+#define SWRMT_OTA_BLOCK_SIZE        (32U)
 #define SWRMT_OTA_PROTOCOL_VERSION  (2U)
 
 typedef enum {

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -9,8 +9,15 @@
 #define BROADCAST_ADDRESS 0xffffffffffffffffUL  ///< Broadcast address
 #define GATEWAY_ADDRESS   0x0000000000000000UL  ///< Gateway address
 
-#define SWRMT_OTA_CHUNK_SIZE        (64U)
+#define SWRMT_OTA_CHUNK_SIZE        (128U)
 #define SWRMT_OTA_SHA256_LENGTH     (32U)
+
+/// Block-OTA (fast OTA) parameters. W = 22 matches the 22 downlink slots per
+/// Mari "huge" slotframe; the received bitmap is a uint32_t so W may grow to 32
+/// without a wire change. The protocol version is echoed in OTA_START_ACK so the
+/// controller knows the bootloader speaks the block/bitmap path.
+#define SWRMT_OTA_BLOCK_SIZE        (22U)
+#define SWRMT_OTA_PROTOCOL_VERSION  (2U)
 
 typedef enum {
     SWRMT_DEVICE_TYPE_UNKNOWN = 0,
@@ -38,6 +45,10 @@ typedef enum {
     SWRMT_MSG_OTA_CHUNK_ACK = 0x87,
     SWRMT_MSG_GPIO_EVENT = 0x88,
     SWRMT_MSG_LOG_EVENT = 0x89,
+    SWRMT_MSG_OTA_BLOCK_REPORT_REQ = 0x8A,   // host -> device: request received bitmap
+    SWRMT_MSG_OTA_BLOCK_REPORT_RESP = 0x8B,  // device -> host: received bitmap for a block
+    SWRMT_MSG_OTA_FINALIZE = 0x8C,           // host -> device: verify whole-image SHA256
+    SWRMT_MSG_OTA_FINALIZE_RESP = 0x8D,      // device -> host: image SHA256 match result
     // FIXME: we need better namespacing for these messages, for example,
     // use 0x80 for SwarmIT application type, and then use an internal namespace for SwarmIT messages,
     // like 0x80.0x01 for SwarmIT status, 0x80.0x02 for SwarmIT start, etc.
@@ -88,6 +99,25 @@ typedef struct __attribute__((packed)) {
     uint8_t  sha[8];
     uint8_t  chunk[SWRMT_OTA_CHUNK_SIZE];       ///< Bytes array of the firmware chunk
 } swrmt_ota_chunk_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t block_index;                       ///< Block the controller is asking about
+    uint8_t  block_size;                        ///< Chunks per block (W)
+} swrmt_ota_block_report_req_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t block_index;                       ///< Block the device currently holds
+    uint32_t received_mask;                     ///< Bit i set: chunk block_index*W+i written
+    uint8_t  status;                            ///< Reserved (0)
+} swrmt_ota_block_report_resp_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  sha[SWRMT_OTA_SHA256_LENGTH];      ///< Expected SHA256 of the whole image
+} swrmt_ota_finalize_pkt_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  ok;                                ///< 1 if the image SHA256 matched
+} swrmt_ota_finalize_resp_pkt_t;
 
 typedef struct __attribute__((packed)) {
     uint32_t homography_count;              ///< number of homography matrices used for localization

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -42,7 +42,7 @@ typedef enum {
     SWRMT_MSG_OTA_START = 0x84,
     SWRMT_MSG_OTA_CHUNK = 0x85,
     SWRMT_MSG_OTA_START_ACK = 0x86,
-    SWRMT_MSG_OTA_CHUNK_ACK = 0x87,
+    SWRMT_MSG_OTA_CHUNK_ACK = 0x87,          // retired with the per-chunk OTA path; id kept reserved
     SWRMT_MSG_GPIO_EVENT = 0x88,
     SWRMT_MSG_LOG_EVENT = 0x89,
     SWRMT_MSG_OTA_BLOCK_REPORT_REQ = 0x8A,   // host -> device: request received bitmap

--- a/device/network_core/Source/protocol.h
+++ b/device/network_core/Source/protocol.h
@@ -91,6 +91,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint32_t image_size;                        ///< User image size in bytes
     uint32_t chunk_count;
+    uint8_t  version;                           ///< OTA protocol version (2 = block; absent/other = legacy)
 } swrmt_ota_start_pkt_t;
 
 typedef struct __attribute__((packed)) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ addopts = """
 testpaths = [
     "swarmit",
 ]
+markers = [
+    "transport_mock: exercises protocol logic against a mocked transport; does not count as hardware validation (no-mock rule)",
+]
 
 [tool.ruff]
 lint.select = ["E", "F"]

--- a/swarmit-bootloader-dotbot-v2.emProject
+++ b/swarmit-bootloader-dotbot-v2.emProject
@@ -29,7 +29,7 @@
     c_additional_options="-Wall;-Wextra;-Wunused-variable;-Wuninitialized;-Wmissing-field-initializers;-Wundef;-ffunction-sections;-fdata-sections"
     c_only_additional_options="-Wno-missing-prototypes;-Wno-strict-prototypes"
     c_preprocessor_definitions="ARM_MATH_ARMV8MML;NRF5340_XXAA;NRF_APPLICATION;__NRF_FAMILY;CONFIG_NFCT_PINS_AS_GPIOS;BOARD_DOTBOT_V2;USE_LH2"
-    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
+    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
     compile_post_build_command=""
     compiler_color_diagnostics="Yes"
     debug_register_definition_file="$(ProjectDir)/Setup/nrf5340_application_Registers.xml"

--- a/swarmit-bootloader-dotbot-v3.emProject
+++ b/swarmit-bootloader-dotbot-v3.emProject
@@ -29,7 +29,7 @@
     c_additional_options="-Wall;-Wextra;-Wunused-variable;-Wuninitialized;-Wmissing-field-initializers;-Wundef;-ffunction-sections;-fdata-sections"
     c_only_additional_options="-Wno-missing-prototypes;-Wno-strict-prototypes"
     c_preprocessor_definitions="ARM_MATH_ARMV8MML;NRF5340_XXAA;NRF_APPLICATION;__NRF_FAMILY;CONFIG_NFCT_PINS_AS_GPIOS;BOARD_DOTBOT_V3;USE_LH2"
-    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
+    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
     compile_post_build_command=""
     compiler_color_diagnostics="Yes"
     debug_register_definition_file="$(ProjectDir)/Setup/nrf5340_application_Registers.xml"

--- a/swarmit-bootloader-nrf5340dk.emProject
+++ b/swarmit-bootloader-nrf5340dk.emProject
@@ -29,7 +29,7 @@
     c_additional_options="-Wall;-Wextra;-Wunused-variable;-Wuninitialized;-Wmissing-field-initializers;-Wundef;-ffunction-sections;-fdata-sections"
     c_only_additional_options="-Wno-missing-prototypes;-Wno-strict-prototypes"
     c_preprocessor_definitions="ARM_MATH_ARMV8MML;NRF5340_XXAA;NRF_APPLICATION;__NRF_FAMILY;CONFIG_NFCT_PINS_AS_GPIOS;BOARD_NRF5340DK;USE_LH2"
-    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
+    c_user_include_directories="$(SolutionDir)/../../dotbot-libs/bsp;$(SolutionDir)/../../dotbot-libs/drv;$(SolutionDir)/../../dotbot-libs/crypto;$(PackagesDir)/nRF/Device/Include;$(PackagesDir)/CMSIS_5/CMSIS/Core/Include"
     compile_post_build_command=""
     compiler_color_diagnostics="Yes"
     debug_register_definition_file="$(ProjectDir)/Setup/nrf5340_application_Registers.xml"

--- a/swarmit/cli/config_sample.toml
+++ b/swarmit/cli/config_sample.toml
@@ -12,3 +12,14 @@ devices = ""
 # adapter = "edge"
 # serial_port = "/dev/ttyACM0"
 # baudrate = 1000000
+
+# OTA pacing. The flash transfer derives its send rate from the schedule the
+# gateway reports, so these rarely need touching.
+# Share of the downlink slots OTA may drive (the rest stays free for beacons,
+# joins and commands):
+# ota_utilization = 0.75
+# Per-bot chunk-write ceiling in chunks/s (SHA verify + flash write):
+# ota_device_chunk_rate = 84.0
+# Report-collection window in seconds; 0 derives it from the schedule. Raise it
+# if reports arrive late (a slow broker) and cause spurious repair rounds:
+# ota_report_timeout = 0

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -546,7 +546,9 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                     if n_blocks and per_device_acked:
                         # Blocks fully delivered to the slowest bot, so the
                         # indicator only advances once every bot has the block.
-                        done_blocks = min(per_device_acked.values()) // block_size
+                        done_blocks = (
+                            min(per_device_acked.values()) // block_size
+                        )
                         progress.set_postfix_str(
                             f"blk {min(done_blocks, n_blocks)}/{n_blocks}"
                         )

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -515,11 +515,6 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                     )
                     n_blocks = ev.get("n_blocks", 0)
                     block_size = ev.get("block_size", 1) or 1
-                    algo = (
-                        "block OTA"
-                        if ev.get("path") == "block"
-                        else "per-chunk"
-                    )
                     progress = tqdm(
                         total=ev["total_chunks"] * len(ev["devices"]),
                         unit="chunk",
@@ -528,7 +523,7 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                         ncols=100,
                     )
                     progress.set_description(
-                        f"Flashing {len(ev['devices'])} bot(s) · {algo}"
+                        f"Flashing {len(ev['devices'])} bot(s)"
                     )
                 elif etype == "chunk":
                     if progress is None:

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -16,6 +16,10 @@ from tqdm import tqdm
 
 from swarmit import __version__
 from swarmit.client import build_client
+from swarmit.testbed.adapter import (
+    DEVICE_CHUNK_RATE_HZ,
+    OTA_DOWNLINK_UTILIZATION,
+)
 from swarmit.testbed.controller import (
     CHUNK_SIZE,
     OTA_ACK_TIMEOUT_DEFAULT,
@@ -171,6 +175,11 @@ DEFAULTS = {
     # See https://crystalfree.atlassian.net/wiki/spaces/Mari/pages/3324903426/Registry+of+Mari+Network+IDs
     "swarmit_network_id": "1200",
     "mqtt_use_tls": False,
+    # OTA pacing. The transfer paces itself from the schedule the gateway
+    # reports; these scale that derivation. 0 means "derive it".
+    "ota_utilization": OTA_DOWNLINK_UTILIZATION,
+    "ota_device_chunk_rate": DEVICE_CHUNK_RATE_HZ,
+    "ota_report_timeout": 0,
     "verbose": False,
 }
 
@@ -344,6 +353,9 @@ def main(
         network_id=int(final_config["swarmit_network_id"], 16),
         adapter=final_config["adapter"],
         devices=[d for d in final_config["devices"].split(",") if d],
+        ota_utilization=float(final_config["ota_utilization"]),
+        ota_device_chunk_rate=float(final_config["ota_device_chunk_rate"]),
+        ota_report_timeout=float(final_config["ota_report_timeout"]),
         verbose=final_config["verbose"],
     )
 

--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -500,6 +500,8 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
         progress = None
         per_device_acked: dict[str, int] = {}
         device_results: list[dict] = []
+        n_blocks = 0
+        block_size = 1
         try:
             for ev in events:
                 etype = ev.get("type")
@@ -511,6 +513,13 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                         f"Radio chunks ([bold]{CHUNK_SIZE}B[/bold]): "
                         f"{ev['total_chunks']}"
                     )
+                    n_blocks = ev.get("n_blocks", 0)
+                    block_size = ev.get("block_size", 1) or 1
+                    algo = (
+                        "block OTA"
+                        if ev.get("path") == "block"
+                        else "per-chunk"
+                    )
                     progress = tqdm(
                         total=ev["total_chunks"] * len(ev["devices"]),
                         unit="chunk",
@@ -519,7 +528,7 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                         ncols=100,
                     )
                     progress.set_description(
-                        f"Flashing {len(ev['devices'])} bot(s)"
+                        f"Flashing {len(ev['devices'])} bot(s) · {algo}"
                     )
                 elif etype == "chunk":
                     if progress is None:
@@ -527,6 +536,13 @@ def flash(ctx, yes, start, ota_timeout, ota_max_retries, firmware):
                     prev = per_device_acked.get(ev["addr"], 0)
                     progress.update(ev["acked"] - prev)
                     per_device_acked[ev["addr"]] = ev["acked"]
+                    if n_blocks and per_device_acked:
+                        # Blocks fully delivered to the slowest bot, so the
+                        # indicator only advances once every bot has the block.
+                        done_blocks = min(per_device_acked.values()) // block_size
+                        progress.set_postfix_str(
+                            f"blk {min(done_blocks, n_blocks)}/{n_blocks}"
+                        )
                 elif etype == "device_done":
                     device_results.append(ev)
                 elif etype == "complete":

--- a/swarmit/client/local.py
+++ b/swarmit/client/local.py
@@ -99,12 +99,22 @@ class LocalSwarmitClient:
             }
             return
 
+        path = self._controller.select_ota_path(start_data["acked"])
+        block_size = self._controller.ota_block_size
+        total_chunks = len(self._controller.chunks)
         yield {
             "type": "flash_started",
             "image_size": len(fw),
-            "total_chunks": len(self._controller.chunks),
+            "total_chunks": total_chunks,
             "fw_hash": start_data["ota"].fw_hash.hex().upper(),
             "devices": sorted(start_data["acked"]),
+            "path": path,
+            "block_size": block_size,
+            "n_blocks": (
+                (total_chunks + block_size - 1) // block_size
+                if path == "block"
+                else 0
+            ),
         }
 
         # Run transfer in a thread; poll transfer_data while it runs.

--- a/swarmit/client/local.py
+++ b/swarmit/client/local.py
@@ -99,7 +99,18 @@ class LocalSwarmitClient:
             }
             return
 
-        path = self._controller.select_ota_path(start_data["acked"])
+        stale = self._controller.stale_bootloaders(start_data["acked"])
+        if stale:
+            yield {
+                "type": "error",
+                "message": (
+                    f"{len(stale)} device(s) run a bootloader older than the "
+                    f"block OTA protocol: {stale}. Re-provision them with "
+                    "'dotbot device flash-swarmit-sandbox'."
+                ),
+            }
+            return
+
         block_size = self._controller.ota_block_size
         total_chunks = len(self._controller.chunks)
         yield {
@@ -108,13 +119,8 @@ class LocalSwarmitClient:
             "total_chunks": total_chunks,
             "fw_hash": start_data["ota"].fw_hash.hex().upper(),
             "devices": sorted(start_data["acked"]),
-            "path": path,
             "block_size": block_size,
-            "n_blocks": (
-                (total_chunks + block_size - 1) // block_size
-                if path == "block"
-                else 0
-            ),
+            "n_blocks": (total_chunks + block_size - 1) // block_size,
         }
 
         # Run transfer in a thread; poll transfer_data while it runs.

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -74,7 +74,9 @@ class LinkGeometry:
     @classmethod
     def fallback(cls) -> "LinkGeometry":
         """Geometry to pace with when the gateway has not reported one."""
-        return replace(cls.from_schedule_id(FALLBACK_SCHEDULE_ID), reported=False)
+        return replace(
+            cls.from_schedule_id(FALLBACK_SCHEDULE_ID), reported=False
+        )
 
 
 def derive_block_settings(
@@ -97,7 +99,9 @@ def derive_block_settings(
     )
     # Every bot reports within one slotframe; give the collection window two,
     # plus a slotframe for each extra fleet-full of uplink cells.
-    report_slotframes = 2.0 + max(0, n_bots - 1) / max(1, geometry.uplink_cells)
+    report_slotframes = 2.0 + max(0, n_bots - 1) / max(
+        1, geometry.uplink_cells
+    )
     return BlockOTASettings(
         block_size=BLOCK_SIZE_DEFAULT,
         inter_chunk_delay=1.0 / inject_pps,
@@ -190,7 +194,9 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
         self.mari.serial_interface.close()
 
     def link_geometry(self) -> LinkGeometry | None:
-        return LinkGeometry.from_schedule_id(self.mari.gateway.info.schedule_id)
+        return LinkGeometry.from_schedule_id(
+            self.mari.gateway.info.schedule_id
+        )
 
     def send_payload(self, destination: int, payload: Payload):
         self.mari.send_frame(

--- a/swarmit/testbed/adapter.py
+++ b/swarmit/testbed/adapter.py
@@ -1,8 +1,16 @@
-"""Module containing classes for interfacing with the DotBot gateway."""
+"""Module containing classes for interfacing with the DotBot gateway.
+
+This is the one module that knows how the radio works. Everything above it
+sends payloads to addresses; the Mari specifics - schedules, slotframes,
+downlink cells - stop here. That includes the OTA pacing model: how fast
+chunks may be injected is a property of the link, so it is derived here from
+the geometry the gateway reports rather than hardcoded upstream.
+"""
 
 import sys
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, replace
 
 from dotbot_utils.protocol import (
     Packet,
@@ -15,8 +23,86 @@ from marilib.mari_protocol import Frame as MariFrame
 from marilib.mari_protocol import NextProto
 from marilib.marilib_cloud import MarilibCloud
 from marilib.marilib_edge import MarilibEdge
-from marilib.model import EdgeEvent, MariNode
+from marilib.model import SCHEDULES, EdgeEvent, MariNode
 from rich import print
+
+from swarmit.testbed.ota import BLOCK_SIZE_DEFAULT, BlockOTASettings
+
+# Share of the gateway's downlink slots OTA is allowed to drive. The rest is
+# left for beacons, joins and commands, and as headroom against the gateway's
+# shared TX queue.
+OTA_DOWNLINK_UTILIZATION = 0.75
+# Ceiling on how fast a bot can take chunks: SHA-verify on the net core, then a
+# flash write on the app core. Measured on hardware at ~84/s, which is above
+# the downlink capacity of every schedule - so the radio binds, not the device.
+DEVICE_CHUNK_RATE_HZ = 84.0
+# Used when the gateway has not reported its schedule yet. The mid-size
+# schedule is the conservative choice: pacing derived from it under-drives a
+# bigger schedule rather than overrunning a smaller one.
+FALLBACK_SCHEDULE_ID = 4  # "medium"
+
+
+@dataclass(frozen=True)
+class LinkGeometry:
+    """Capacity of the Mari link the gateway is currently running.
+
+    Built from the schedule the gateway announces. A gateway sends one
+    downlink frame per D-cell per slotframe, and every joined node owns one
+    uplink cell per slotframe (so a whole fleet can report within one).
+    """
+
+    schedule_name: str
+    slotframe_s: float
+    downlink_pps: float
+    uplink_cells: int
+    reported: bool = True
+
+    @classmethod
+    def from_schedule_id(cls, schedule_id: int) -> "LinkGeometry | None":
+        """Build from a Mari schedule id, or None if it is unknown."""
+        schedule = SCHEDULES.get(schedule_id)
+        if not schedule or not schedule["sf_duration"]:
+            return None
+        slotframe_s = schedule["sf_duration"] / 1000.0
+        return cls(
+            schedule_name=schedule["name"],
+            slotframe_s=slotframe_s,
+            downlink_pps=schedule["d_down"] / slotframe_s,
+            uplink_cells=schedule["max_nodes"],
+        )
+
+    @classmethod
+    def fallback(cls) -> "LinkGeometry":
+        """Geometry to pace with when the gateway has not reported one."""
+        return replace(cls.from_schedule_id(FALLBACK_SCHEDULE_ID), reported=False)
+
+
+def derive_block_settings(
+    geometry: "LinkGeometry | None",
+    n_bots: int = 1,
+    utilization: float = OTA_DOWNLINK_UTILIZATION,
+    device_chunk_rate: float = DEVICE_CHUNK_RATE_HZ,
+) -> BlockOTASettings:
+    """Derive OTA block-transfer pacing from the link and the fleet size.
+
+    Chunks are broadcast, so one frame reaches every bot and the send rate is
+    independent of fleet size: it is the downlink capacity we are allowed to
+    use, capped by what a bot can absorb. Fleet size only widens the report
+    window, since the bots answer in their own uplink cells.
+    """
+    if geometry is None:
+        geometry = LinkGeometry.fallback()
+    inject_pps = max(
+        1.0, min(geometry.downlink_pps * utilization, device_chunk_rate)
+    )
+    # Every bot reports within one slotframe; give the collection window two,
+    # plus a slotframe for each extra fleet-full of uplink cells.
+    report_slotframes = 2.0 + max(0, n_bots - 1) / max(1, geometry.uplink_cells)
+    return BlockOTASettings(
+        block_size=BLOCK_SIZE_DEFAULT,
+        inter_chunk_delay=1.0 / inject_pps,
+        report_timeout=geometry.slotframe_s * report_slotframes,
+    )
 
 
 class GatewayAdapterBase(ABC):
@@ -33,6 +119,10 @@ class GatewayAdapterBase(ABC):
     @abstractmethod
     def send_payload(self, destination: int, payload: Payload):
         """Send payload to the interface."""
+
+    def link_geometry(self) -> LinkGeometry | None:
+        """Capacity of the link, or None if the gateway has not reported it."""
+        return None
 
 
 class MarilibEdgeAdapter(GatewayAdapterBase):
@@ -98,6 +188,9 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
 
     def close(self):
         self.mari.serial_interface.close()
+
+    def link_geometry(self) -> LinkGeometry | None:
+        return LinkGeometry.from_schedule_id(self.mari.gateway.info.schedule_id)
 
     def send_payload(self, destination: int, payload: Payload):
         self.mari.send_frame(
@@ -184,6 +277,15 @@ class MarilibCloudAdapter(GatewayAdapterBase):
 
     def close(self):
         pass
+
+    def link_geometry(self) -> LinkGeometry | None:
+        # Several gateways may be on the same network. They run the same
+        # schedule, so the first one that has reported answers for all.
+        for gateway in self.mari.gateways.values():
+            geometry = LinkGeometry.from_schedule_id(gateway.info.schedule_id)
+            if geometry is not None:
+                return geometry
+        return None
 
     def send_payload(self, destination: int, payload: Payload):
         self.mari.send_frame(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1041,11 +1041,21 @@ class Controller:
             on_progress=on_progress,
             logger=self.logger,
         )
+        self.logger.info(
+            "ota transfer start",
+            path="block",
+            image_bytes=data_size,
+            total_chunks=len(self.chunks),
+            block_size=transfer.settings.block_size,
+            devices=len(devices),
+        )
         self._block_transfer = transfer
+        start_ts = time.time()
         try:
             results = transfer.run()
         finally:
             self._block_transfer = None
+        elapsed = time.time() - start_ts
         if progress is not None:
             progress.close()
 
@@ -1055,9 +1065,20 @@ class Controller:
                 td.success = result.success
         delivered = sum(r.confirmed_chunks for r in results.values())
         waste = transfer.chunk_sends / delivered if delivered else 0
+        rate = delivered / elapsed if elapsed else 0
+        self.logger.info(
+            "ota transfer complete",
+            path="block",
+            elapsed_s=round(elapsed, 2),
+            chunk_sends=transfer.chunk_sends,
+            delivered=delivered,
+            waste_ratio=round(waste, 2),
+            chunk_per_s=round(rate, 2),
+        )
         print(
             f"[dim]block OTA: {transfer.chunk_sends} chunk sends for "
-            f"{delivered} delivered (waste x{waste:.2f})[/]"
+            f"{delivered} delivered (waste x{waste:.2f}), "
+            f"{elapsed:.1f}s, {rate:.1f} chunk/s[/]"
         )
         if self.settings.verbose:
             for addr, result in results.items():
@@ -1108,6 +1129,14 @@ class Controller:
         self.logger.info("ota path selected", path="legacy", versions=versions)
 
         data_size = len(firmware)
+        self.logger.info(
+            "ota transfer start",
+            path="legacy",
+            image_bytes=data_size,
+            total_chunks=len(self.chunks),
+            devices=len(devices),
+        )
+        legacy_start_ts = time.time()
         use_progress_bar = show_progress and not self.settings.verbose
         if use_progress_bar:
             progress = tqdm(
@@ -1157,4 +1186,22 @@ class Controller:
                     chunk.acked for chunk in device_data.chunks
                 )
                 self.transfer_data[device] = device_data
+        legacy_elapsed = time.time() - legacy_start_ts
+        delivered = sum(
+            sum(1 for c in td.chunks if c.acked)
+            for td in self.transfer_data.values()
+        )
+        total_retries = sum(
+            c.retries for td in self.transfer_data.values() for c in td.chunks
+        )
+        self.logger.info(
+            "ota transfer complete",
+            path="legacy",
+            elapsed_s=round(legacy_elapsed, 2),
+            delivered=delivered,
+            retries=total_retries,
+            chunk_per_s=round(
+                delivered / legacy_elapsed if legacy_elapsed else 0, 2
+            ),
+        )
         return self.transfer_data

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -19,18 +19,16 @@ from rich.text import Text
 from tqdm import tqdm
 
 from swarmit.testbed.adapter import (
-    GatewayAdapterBase,
-    MarilibCloudAdapter,
-    MarilibEdgeAdapter,
-)
-from swarmit.testbed.logger import LOGGER
-from swarmit.testbed.ota import (
-    BLOCK_SIZE_DEFAULT,
     DEVICE_CHUNK_RATE_HZ,
     OTA_DOWNLINK_UTILIZATION,
-    BlockTransfer,
-    settings_for_fleet,
+    GatewayAdapterBase,
+    LinkGeometry,
+    MarilibCloudAdapter,
+    MarilibEdgeAdapter,
+    derive_block_settings,
 )
+from swarmit.testbed.logger import LOGGER
+from swarmit.testbed.ota import BLOCK_SIZE_DEFAULT, BlockTransfer
 from swarmit.testbed.protocol import (
     OTA_PROTOCOL_VERSION_BLOCK,
     OTA_PROTOCOL_VERSION_LEGACY,
@@ -64,6 +62,19 @@ BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 VOLTAGE_MAX = 3000  # mV
 VOLTAGE_FULL = 2900  # mV
 VOLTAGE_WARNING = 1500  # mV
+
+
+def _test_drop_chunks() -> set[int]:
+    """Chunk indices to silently never transmit (fault injection).
+
+    Set SWARMIT_OTA_TEST_DROP=200,201 to prove the finalize SHA256 rejects an
+    incomplete image. This is a test seam, not configuration, which is why it
+    lives in the environment and not in the settings file.
+    """
+    raw = os.environ.get("SWARMIT_OTA_TEST_DROP", "")
+    return {
+        int(x) for x in raw.split(",") if x.strip().lstrip("-").isdigit()
+    }
 
 
 class StaleBootloaderError(Exception):
@@ -409,8 +420,17 @@ class ControllerSettings:
     map_size: str = "2500x2500"
     # in mm; 0 = infer from map_size as min(w, h) / 5
     calibration_distance: int = 0
+    # OTA_START retry budget (the block transfer does its own repair rounds).
     ota_max_retries: int = OTA_MAX_RETRIES_DEFAULT
     ota_timeout: float = OTA_ACK_TIMEOUT_DEFAULT
+    # Share of the gateway's downlink the OTA transfer may drive, and the
+    # per-bot chunk-write ceiling. Together they set the chunk inject rate.
+    ota_utilization: float = OTA_DOWNLINK_UTILIZATION
+    ota_device_chunk_rate: float = DEVICE_CHUNK_RATE_HZ
+    # Report-collection window in seconds; 0 derives it from the link geometry.
+    # Too short and a report arriving after the broker round trip reads as
+    # missing, costing a spurious repair round.
+    ota_report_timeout: float = 0
     adapter_wait_timeout: float = 3
     verbose: bool = False
 
@@ -1007,34 +1027,28 @@ class Controller:
                     progress.update(self.chunks[chunk_index].size)
 
         broadcast = not self.settings.devices
-        # Test hook: SWARMIT_OTA_TEST_DROP=200,201 makes the transfer never send
-        # those chunks, to verify the finalize SHA rejects an incomplete image.
-        drop_env = os.environ.get("SWARMIT_OTA_TEST_DROP", "")
-        drop_chunks = {
-            int(x) for x in drop_env.split(",") if x.strip().lstrip("-").isdigit()
-        }
+        drop_chunks = _test_drop_chunks()
         if drop_chunks:
-            self.logger.warning("ota test: dropping chunks", chunks=sorted(drop_chunks))
-        # Pacing is derived from the Mari schedule geometry and fleet size, but
-        # currently clamped to the device's single-buffer chunk rate (see
-        # ota.DEVICE_CHUNK_RATE_HZ). Schedule + utilization are env-overridable
-        # for the eventual flip once the firmware ring lands.
-        schedule = os.environ.get("SWARMIT_MARI_SCHEDULE", "medium")
-        utilization = float(
-            os.environ.get("SWARMIT_OTA_UTILIZATION", OTA_DOWNLINK_UTILIZATION)
+            self.logger.warning(
+                "ota test: dropping chunks", chunks=sorted(drop_chunks)
+            )
+        # Pacing comes from the link the gateway reports; the adapter owns that
+        # derivation because it owns everything radio-shaped.
+        geometry = self.interface.link_geometry()
+        if geometry is None:
+            self.logger.warning(
+                "ota pacing: gateway has not reported a schedule, "
+                "using the fallback",
+                schedule=LinkGeometry.fallback().schedule_name,
+            )
+        settings = derive_block_settings(
+            geometry,
+            len(devices),
+            self.settings.ota_utilization,
+            self.settings.ota_device_chunk_rate,
         )
-        device_rate = float(
-            os.environ.get("SWARMIT_OTA_DEVICE_RATE", DEVICE_CHUNK_RATE_HZ)
-        )
-        settings = settings_for_fleet(
-            schedule, len(devices), utilization, device_rate
-        )
-        # Experiment knob: override the report-collection window (ms). Too short
-        # and a report that lands after the broker round trip reads as "missing"
-        # -> a spurious repair round.
-        report_ms = os.environ.get("SWARMIT_OTA_REPORT_MS")
-        if report_ms:
-            settings.report_timeout = float(report_ms) / 1000.0
+        if self.settings.ota_report_timeout:
+            settings.report_timeout = self.settings.ota_report_timeout
         transfer = BlockTransfer(
             chunks=self.chunks,
             devices=list(devices),
@@ -1048,10 +1062,9 @@ class Controller:
         )
         self.logger.info(
             "ota transfer start",
-            path="block",
             image_bytes=data_size,
             total_chunks=len(self.chunks),
-            schedule=schedule,
+            schedule=(geometry or LinkGeometry.fallback()).schedule_name,
             block_size=settings.block_size,
             inter_chunk_ms=round(settings.inter_chunk_delay * 1000, 1),
             report_timeout_ms=round(settings.report_timeout * 1000, 1),
@@ -1077,7 +1090,6 @@ class Controller:
         failed = {a: r for a, r in results.items() if not r.success}
         self.logger.info(
             "ota transfer complete",
-            path="block",
             elapsed_s=round(elapsed, 2),
             chunk_sends=transfer.chunk_sends,
             delivered=delivered,

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -30,6 +30,7 @@ from swarmit.testbed.adapter import (
 from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.ota import BLOCK_SIZE_DEFAULT, BlockTransfer
 from swarmit.testbed.protocol import (
+    BROADCAST_ADDRESS,
     OTA_PROTOCOL_VERSION_BLOCK,
     OTA_PROTOCOL_VERSION_LEGACY,
     DeviceType,
@@ -58,7 +59,6 @@ MONITOR_TIMEOUT = 60  # s
 OTA_MAX_RETRIES_DEFAULT = 10
 OTA_ACK_TIMEOUT_DEFAULT = 0.7
 SERIAL_PORT_DEFAULT = get_default_port()
-BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 VOLTAGE_MAX = 3000  # mV
 VOLTAGE_FULL = 2900  # mV
 VOLTAGE_WARNING = 1500  # mV

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -39,7 +39,6 @@ from swarmit.testbed.protocol import (
     PayloadCalibrationData,
     PayloadLH2Capture,
     PayloadMessage,
-    PayloadOTAChunk,
     PayloadOTAStart,
     PayloadReset,
     PayloadStart,
@@ -65,6 +64,23 @@ BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 VOLTAGE_MAX = 3000  # mV
 VOLTAGE_FULL = 2900  # mV
 VOLTAGE_WARNING = 1500  # mV
+
+
+class StaleBootloaderError(Exception):
+    """Raised when a target bot's bootloader predates the block OTA protocol.
+
+    Such a bot only speaks the retired per-chunk protocol, so it cannot be
+    flashed over the air. Re-provision it over J-Link with
+    ``dotbot device flash-swarmit-sandbox``.
+    """
+
+    def __init__(self, devices):
+        self.devices = list(devices)
+        super().__init__(
+            f"{len(self.devices)} device(s) run a bootloader older than the "
+            f"block OTA protocol: {', '.join(self.devices)}. Re-provision "
+            "them with 'dotbot device flash-swarmit-sandbox'."
+        )
 
 
 @dataclass
@@ -589,23 +605,13 @@ class Controller:
                     device_addr, bool(packet.payload.ok)
                 )
         elif packet.payload_type == PayloadType.SWARMIT_OTA_CHUNK_ACK:
-            try:
-                acked = bool(
-                    self.transfer_data[device_addr]
-                    .chunks[packet.payload.index]
-                    .acked
-                )
-            except (IndexError, KeyError):
-                self.logger.debug(
-                    "Chunk index out of range",
-                    device_addr=device_addr,
-                    chunk_index=packet.payload.index,
-                )
-                return
-            if acked is False:
-                self.transfer_data[device_addr].chunks[
-                    packet.payload.index
-                ].acked = 1
+            # Retired with the per-chunk path. Only a bootloader older than
+            # this controller supports still sends these; parse and drop.
+            self.logger.debug(
+                "ignoring retired per-chunk ack",
+                device_addr=device_addr,
+                chunk_index=packet.payload.index,
+            )
         elif packet.payload_type == PayloadType.SWARMIT_EVENT_LOG:
             if (
                 self.settings.devices
@@ -925,104 +931,48 @@ class Controller:
             ),
         }
 
-    def send_chunk(
-        self,
-        chunk: DataChunk,
-        device_addr: str,
-        devices_to_flash: set[str],
-    ):
-        def is_chunk_acknowledged():
-            if int(device_addr, 16) == BROADCAST_ADDRESS:
-                return sorted(self.transfer_data.keys()) == sorted(
-                    devices_to_flash
-                ) and all(
-                    [
-                        status.chunks[chunk.index].acked
-                        for status in self.transfer_data.values()
-                    ]
-                )
-            else:
-                return (
-                    device_addr in self.transfer_data.keys()
-                    and self.transfer_data[device_addr]
-                    .chunks[chunk.index]
-                    .acked
-                )
-
-        payload = PayloadOTAChunk(
-            index=chunk.index,
-            count=chunk.size,
-            sha=chunk.sha,
-            chunk=chunk.data,
-        )
-        send_time = time.time()
-        send = True
-        retries_count = 0
-        while (
-            not is_chunk_acknowledged()
-            and retries_count <= self.settings.ota_max_retries
-        ):
-            if send is True:
-                self.send_payload(int(device_addr, 16), payload)
-                if self.settings.verbose:
-                    missing_acks = [
-                        addr
-                        for addr in devices_to_flash
-                        if addr not in self.transfer_data
-                        or not self.transfer_data[addr]
-                        .chunks[chunk.index]
-                        .acked
-                    ]
-                    print(
-                        f"Transferring chunk {chunk.index + 1}/{self.start_ota_data.chunks} to {device_addr} "
-                        f"- {retries_count} retries "
-                        f"- {len(missing_acks)} missing acks: {', '.join(missing_acks) if missing_acks else 'none'}"
-                    )
-                if int(device_addr, 16) == BROADCAST_ADDRESS:
-                    for addr in devices_to_flash:
-                        self.transfer_data[addr].chunks[
-                            chunk.index
-                        ].retries = retries_count
-                else:
-                    self.transfer_data[device_addr].chunks[
-                        chunk.index
-                    ].retries = retries_count
-                send_time = time.time()
-                retries_count += 1
-            time.sleep(0.001)
-            send = time.time() - send_time > self.settings.ota_timeout
-
     @property
     def ota_block_size(self) -> int:
-        """Chunks per block used by the block-OTA path."""
+        """Chunks per block used by the OTA transfer."""
         return BLOCK_SIZE_DEFAULT
 
-    def select_ota_path(self, devices) -> str:
-        """'block' if every target bot negotiated the block protocol, else 'legacy'."""
-        if not devices:
-            return "legacy"
-        return (
-            "block"
-            if all(
-                self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
-                >= OTA_PROTOCOL_VERSION_BLOCK
-                for addr in devices
-            )
-            else "legacy"
+    def stale_bootloaders(self, devices) -> list[str]:
+        """Devices whose OTA_START_ACK did not announce the block protocol.
+
+        Their bootloader predates the block/bitmap path and only understands
+        the retired per-chunk protocol. They cannot be flashed over the air by
+        this controller; they need a re-provision over J-Link.
+        """
+        return sorted(
+            addr
+            for addr in devices
+            if self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
+            < OTA_PROTOCOL_VERSION_BLOCK
         )
 
-    def _transfer_block_protocol(
+    def transfer(
         self,
         firmware,
         devices,
         show_progress: bool = True,
     ) -> dict[str, TransferDataStatus]:
-        """Transfer the image with the block / bitmap-NACK protocol.
+        """Transfer the firmware to the devices with the block/bitmap protocol.
 
-        Populates ``self.transfer_data`` (acked bits, success) exactly like the
-        legacy path so callers - the daemon stream, LocalSwarmitClient.flash -
-        keep working unchanged.
+        `show_progress` controls the built-in tqdm bar. Clients that render
+        their own progress (e.g. the daemon's /flash/stream or
+        LocalSwarmitClient.flash) pass False to avoid duplicate output.
+
+        Raises ``StaleBootloaderError`` if any target bot still runs a
+        pre-block bootloader, before a single chunk goes on the wire.
         """
+        stale = self.stale_bootloaders(devices)
+        if stale:
+            self.logger.error(
+                "ota aborted: stale bootloaders",
+                devices=stale,
+                required_version=OTA_PROTOCOL_VERSION_BLOCK,
+            )
+            raise StaleBootloaderError(stale)
         data_size = len(firmware)
         use_progress_bar = show_progress and not self.settings.verbose
         progress = None
@@ -1162,114 +1112,4 @@ class Controller:
                     confirmed=result.confirmed_chunks,
                     total=result.total_chunks,
                 )
-        return self.transfer_data
-
-    def transfer(
-        self,
-        firmware,
-        devices,
-        show_progress: bool = True,
-    ) -> dict[str, TransferDataStatus]:
-        """Transfer the firmware to the devices.
-
-        `show_progress` controls the built-in tqdm bar. Clients that
-        render their own progress (e.g. the daemon's /flash/stream or
-        LocalSwarmitClient.flash) pass False to avoid duplicate output.
-        """
-        # Use the block/bitmap path when every target bot negotiated it in its
-        # OTA_START_ACK; otherwise fall back to the legacy per-chunk path for
-        # the whole group. (Per-subset dual-path is a follow-up - see
-        # plans/swarmit-fast-ota/plan.html, Phase 2.)
-        versions = {
-            addr: self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
-            for addr in devices
-        }
-        use_block = self.select_ota_path(devices) == "block"
-        if use_block:
-            self.logger.info(
-                "ota path selected", path="block", versions=versions
-            )
-            return self._transfer_block_protocol(
-                firmware, devices, show_progress
-            )
-        self.logger.info(
-            "ota path selected", path="legacy", versions=versions
-        )
-
-        data_size = len(firmware)
-        self.logger.info(
-            "ota transfer start",
-            path="legacy",
-            image_bytes=data_size,
-            total_chunks=len(self.chunks),
-            devices=len(devices),
-        )
-        legacy_start_ts = time.time()
-        use_progress_bar = show_progress and not self.settings.verbose
-        if use_progress_bar:
-            progress = tqdm(
-                range(0, data_size),
-                unit="B",
-                unit_scale=False,
-                colour="green",
-                ncols=100,
-            )
-            progress.set_description(
-                f"Loading firmware ({int(data_size / 1024)}kB)"
-            )
-        self.transfer_data = {}
-        for _addr in devices:
-            self.transfer_data[_addr] = TransferDataStatus()
-            self.transfer_data[_addr].chunks = [
-                Chunk(index=f"{i:03d}", size=f"{self.chunks[i].size:03d}B")
-                for i in range(len(self.chunks))
-            ]
-        for chunk in self.chunks:
-            if not self.settings.devices:
-                self.send_chunk(
-                    chunk,
-                    addr_to_hex(BROADCAST_ADDRESS),
-                    devices,
-                )
-            else:
-                for _addr in devices:
-                    self.send_chunk(chunk, _addr, devices)
-            if use_progress_bar:
-                progress.update(chunk.size)
-        if self.settings.verbose:
-            retries_count = sum(
-                self.transfer_data[_addr].chunks[_chunk].retries
-                for _chunk in range(len(self.chunks))
-                for _addr in devices
-            )
-            if not self.settings.devices:
-                retries_count = int(retries_count / len(devices))
-            print(f"Transfer completed with {retries_count} retries")
-        if use_progress_bar:
-            progress.close()
-        for device in devices:
-            device_data = self.transfer_data.get(device)
-            if device_data:
-                device_data.success = all(
-                    chunk.acked for chunk in device_data.chunks
-                )
-                self.transfer_data[device] = device_data
-        legacy_elapsed = time.time() - legacy_start_ts
-        delivered = sum(
-            sum(1 for c in td.chunks if c.acked)
-            for td in self.transfer_data.values()
-        )
-        total_retries = sum(
-            c.retries for td in self.transfer_data.values() for c in td.chunks
-        )
-        self.logger.info(
-            "ota transfer complete",
-            path="legacy",
-            elapsed_s=round(legacy_elapsed, 2),
-            delivered=delivered,
-            retries=total_retries,
-            chunk_per_s=round(
-                delivered / legacy_elapsed if legacy_elapsed else 0, 2
-            ),
-        )
         return self.transfer_data

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1053,6 +1053,12 @@ class Controller:
             td = self.transfer_data.get(addr)
             if td is not None:
                 td.success = result.success
+        delivered = sum(r.confirmed_chunks for r in results.values())
+        waste = transfer.chunk_sends / delivered if delivered else 0
+        print(
+            f"[dim]block OTA: {transfer.chunk_sends} chunk sends for "
+            f"{delivered} delivered (waste x{waste:.2f})[/]"
+        )
         if self.settings.verbose:
             for addr, result in results.items():
                 print(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1089,6 +1089,7 @@ class Controller:
         delivered = sum(r.confirmed_chunks for r in results.values())
         waste = transfer.chunk_sends / delivered if delivered else 0
         rate = delivered / elapsed if elapsed else 0
+        failed = {a: r for a, r in results.items() if not r.success}
         self.logger.info(
             "ota transfer complete",
             path="block",
@@ -1097,17 +1098,24 @@ class Controller:
             delivered=delivered,
             waste_ratio=round(waste, 2),
             chunk_per_s=round(rate, 2),
+            ok=not failed,
+            failed_devices=len(failed),
         )
-        if self.settings.verbose:
-            for addr, result in results.items():
-                self.logger.info(
-                    "device transfer result",
-                    addr=addr,
-                    confirmed=result.confirmed_chunks,
-                    total=result.total_chunks,
-                    finalized=result.finalized,
-                    straggler=result.straggler,
-                )
+        # Failures are surfaced at WARNING so they reach the console too, with
+        # enough detail to diagnose: which chunks are still missing per bot, and
+        # whether the whole-image finalize passed.
+        for addr, result in failed.items():
+            missing = transfer.missing_chunks(addr)
+            self.logger.warning(
+                "ota device failed",
+                addr=addr,
+                confirmed=result.confirmed_chunks,
+                total=result.total_chunks,
+                finalized=result.finalized,
+                straggler=result.straggler,
+                missing_count=len(missing),
+                missing_chunks=missing[:64],
+            )
         return self.transfer_data
 
     def transfer(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -26,8 +26,9 @@ from swarmit.testbed.adapter import (
 from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.ota import (
     BLOCK_SIZE_DEFAULT,
-    BlockOTASettings,
+    OTA_DOWNLINK_UTILIZATION,
     BlockTransfer,
+    settings_for_fleet,
 )
 from swarmit.testbed.protocol import (
     OTA_PROTOCOL_VERSION_BLOCK,
@@ -1063,12 +1064,21 @@ class Controller:
         }
         if drop_chunks:
             self.logger.warning("ota test: dropping chunks", chunks=sorted(drop_chunks))
+        # Pacing is derived from the Mari schedule geometry and fleet size, but
+        # currently clamped to the device's single-buffer chunk rate (see
+        # ota.DEVICE_CHUNK_RATE_HZ). Schedule + utilization are env-overridable
+        # for the eventual flip once the firmware ring lands.
+        schedule = os.environ.get("SWARMIT_MARI_SCHEDULE", "medium")
+        utilization = float(
+            os.environ.get("SWARMIT_OTA_UTILIZATION", OTA_DOWNLINK_UTILIZATION)
+        )
+        settings = settings_for_fleet(schedule, len(devices), utilization)
         transfer = BlockTransfer(
             chunks=self.chunks,
             devices=list(devices),
             send_payload=self.send_payload,
             image_sha=self.start_ota_data.fw_hash,
-            settings=BlockOTASettings(),
+            settings=settings,
             broadcast=broadcast,
             on_progress=on_progress,
             logger=self.logger,
@@ -1079,7 +1089,10 @@ class Controller:
             path="block",
             image_bytes=data_size,
             total_chunks=len(self.chunks),
-            block_size=transfer.settings.block_size,
+            schedule=schedule,
+            block_size=settings.block_size,
+            inter_chunk_ms=round(settings.inter_chunk_delay * 1000, 1),
+            report_timeout_ms=round(settings.report_timeout * 1000, 1),
             devices=len(devices),
         )
         self._block_transfer = transfer

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -23,7 +23,11 @@ from swarmit.testbed.adapter import (
     MarilibEdgeAdapter,
 )
 from swarmit.testbed.logger import LOGGER
-from swarmit.testbed.ota import BlockOTASettings, BlockTransfer
+from swarmit.testbed.ota import (
+    BLOCK_SIZE_DEFAULT,
+    BlockOTASettings,
+    BlockTransfer,
+)
 from swarmit.testbed.protocol import (
     OTA_PROTOCOL_VERSION_BLOCK,
     OTA_PROTOCOL_VERSION_LEGACY,
@@ -985,6 +989,25 @@ class Controller:
             time.sleep(0.001)
             send = time.time() - send_time > self.settings.ota_timeout
 
+    @property
+    def ota_block_size(self) -> int:
+        """Chunks per block used by the block-OTA path."""
+        return BLOCK_SIZE_DEFAULT
+
+    def select_ota_path(self, devices) -> str:
+        """'block' if every target bot negotiated the block protocol, else 'legacy'."""
+        if not devices:
+            return "legacy"
+        return (
+            "block"
+            if all(
+                self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
+                >= OTA_PROTOCOL_VERSION_BLOCK
+                for addr in devices
+            )
+            else "legacy"
+        )
+
     def _transfer_block_protocol(
         self,
         firmware,
@@ -1075,17 +1098,15 @@ class Controller:
             waste_ratio=round(waste, 2),
             chunk_per_s=round(rate, 2),
         )
-        print(
-            f"[dim]block OTA: {transfer.chunk_sends} chunk sends for "
-            f"{delivered} delivered (waste x{waste:.2f}), "
-            f"{elapsed:.1f}s, {rate:.1f} chunk/s[/]"
-        )
         if self.settings.verbose:
             for addr, result in results.items():
-                print(
-                    f"{addr}: {result.confirmed_chunks}/{result.total_chunks} "
-                    f"chunks, finalized={result.finalized}, "
-                    f"straggler={result.straggler}"
+                self.logger.info(
+                    "device transfer result",
+                    addr=addr,
+                    confirmed=result.confirmed_chunks,
+                    total=result.total_chunks,
+                    finalized=result.finalized,
+                    straggler=result.straggler,
                 )
         return self.transfer_data
 
@@ -1109,24 +1130,17 @@ class Controller:
             addr: self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
             for addr in devices
         }
-        use_block = bool(devices) and all(
-            v >= OTA_PROTOCOL_VERSION_BLOCK for v in versions.values()
-        )
+        use_block = self.select_ota_path(devices) == "block"
         if use_block:
-            print(
-                "[bold green]OTA algorithm: BLOCK / bitmap-NACK (fast OTA)[/] "
-                f"- negotiated versions {versions}"
+            self.logger.info(
+                "ota path selected", path="block", versions=versions
             )
-            self.logger.info("ota path selected", path="block", versions=versions)
             return self._transfer_block_protocol(
                 firmware, devices, show_progress
             )
-        print(
-            "[bold yellow]OTA algorithm: LEGACY per-chunk stop-and-wait[/] "
-            f"- negotiated versions {versions} "
-            f"(need v>={OTA_PROTOCOL_VERSION_BLOCK} from every bot for block OTA)"
+        self.logger.info(
+            "ota path selected", path="legacy", versions=versions
         )
-        self.logger.info("ota path selected", path="legacy", versions=versions)
 
         data_size = len(firmware)
         self.logger.info(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1101,9 +1101,9 @@ class Controller:
             ok=not failed,
             failed_devices=len(failed),
         )
-        # Failures are surfaced at WARNING so they reach the console too, with
-        # enough detail to diagnose: which chunks are still missing per bot, and
-        # whether the whole-image finalize passed.
+        # Genuine failures (finalize SHA did not match, or no finalize response)
+        # are surfaced at WARNING so they reach the console too, with the missing
+        # chunk list for diagnosis.
         for addr, result in failed.items():
             missing = transfer.missing_chunks(addr)
             self.logger.warning(
@@ -1116,6 +1116,17 @@ class Controller:
                 missing_count=len(missing),
                 missing_chunks=missing[:64],
             )
+        # Image is good (finalize passed) but the delivery bitmap under-counted -
+        # a sign the report path churned under load. Not a failure, but worth a
+        # breadcrumb for tuning.
+        for addr, result in results.items():
+            if result.success and result.confirmed_chunks < result.total_chunks:
+                self.logger.info(
+                    "ota bitmap under-tracked",
+                    addr=addr,
+                    confirmed=result.confirmed_chunks,
+                    total=result.total_chunks,
+                )
         return self.transfer_data
 
     def transfer(

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -72,9 +72,7 @@ def _test_drop_chunks() -> set[int]:
     lives in the environment and not in the settings file.
     """
     raw = os.environ.get("SWARMIT_OTA_TEST_DROP", "")
-    return {
-        int(x) for x in raw.split(",") if x.strip().lstrip("-").isdigit()
-    }
+    return {int(x) for x in raw.split(",") if x.strip().lstrip("-").isdigit()}
 
 
 class StaleBootloaderError(Exception):
@@ -1117,7 +1115,10 @@ class Controller:
         # a sign the report path churned under load. Not a failure, but worth a
         # breadcrumb for tuning.
         for addr, result in results.items():
-            if result.success and result.confirmed_chunks < result.total_chunks:
+            if (
+                result.success
+                and result.confirmed_chunks < result.total_chunks
+            ):
                 self.logger.info(
                     "ota bitmap under-tracked",
                     addr=addr,

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1079,6 +1079,12 @@ class Controller:
         settings = settings_for_fleet(
             schedule, len(devices), utilization, device_rate
         )
+        # Experiment knob: override the report-collection window (ms). Too short
+        # and a report that lands after the broker round trip reads as "missing"
+        # -> a spurious repair round.
+        report_ms = os.environ.get("SWARMIT_OTA_REPORT_MS")
+        if report_ms:
+            settings.report_timeout = float(report_ms) / 1000.0
         transfer = BlockTransfer(
             chunks=self.chunks,
             devices=list(devices),

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1,6 +1,7 @@
 """Module containing the swarmit controller class."""
 
 import dataclasses
+import os
 import threading
 import time
 from binascii import hexlify
@@ -1054,6 +1055,14 @@ class Controller:
                     progress.update(self.chunks[chunk_index].size)
 
         broadcast = not self.settings.devices
+        # Test hook: SWARMIT_OTA_TEST_DROP=200,201 makes the transfer never send
+        # those chunks, to verify the finalize SHA rejects an incomplete image.
+        drop_env = os.environ.get("SWARMIT_OTA_TEST_DROP", "")
+        drop_chunks = {
+            int(x) for x in drop_env.split(",") if x.strip().lstrip("-").isdigit()
+        }
+        if drop_chunks:
+            self.logger.warning("ota test: dropping chunks", chunks=sorted(drop_chunks))
         transfer = BlockTransfer(
             chunks=self.chunks,
             devices=list(devices),
@@ -1063,6 +1072,7 @@ class Controller:
             broadcast=broadcast,
             on_progress=on_progress,
             logger=self.logger,
+            drop_chunks=drop_chunks,
         )
         self.logger.info(
             "ota transfer start",

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1078,14 +1078,28 @@ class Controller:
         # OTA_START_ACK; otherwise fall back to the legacy per-chunk path for
         # the whole group. (Per-subset dual-path is a follow-up - see
         # plans/swarmit-fast-ota/plan.html, Phase 2.)
-        if devices and all(
-            self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
-            >= OTA_PROTOCOL_VERSION_BLOCK
+        versions = {
+            addr: self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
             for addr in devices
-        ):
+        }
+        use_block = bool(devices) and all(
+            v >= OTA_PROTOCOL_VERSION_BLOCK for v in versions.values()
+        )
+        if use_block:
+            print(
+                "[bold green]OTA algorithm: BLOCK / bitmap-NACK (fast OTA)[/] "
+                f"- negotiated versions {versions}"
+            )
+            self.logger.info("ota path selected", path="block", versions=versions)
             return self._transfer_block_protocol(
                 firmware, devices, show_progress
             )
+        print(
+            "[bold yellow]OTA algorithm: LEGACY per-chunk stop-and-wait[/] "
+            f"- negotiated versions {versions} "
+            f"(need v>={OTA_PROTOCOL_VERSION_BLOCK} from every bot for block OTA)"
+        )
+        self.logger.info("ota path selected", path="legacy", versions=versions)
 
         data_size = len(firmware)
         use_progress_bar = show_progress and not self.settings.verbose

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -23,7 +23,10 @@ from swarmit.testbed.adapter import (
     MarilibEdgeAdapter,
 )
 from swarmit.testbed.logger import LOGGER
+from swarmit.testbed.ota import BlockOTASettings, BlockTransfer
 from swarmit.testbed.protocol import (
+    OTA_PROTOCOL_VERSION_BLOCK,
+    OTA_PROTOCOL_VERSION_LEGACY,
     DeviceType,
     FaultType,
     PayloadCalibrationData,
@@ -400,6 +403,12 @@ class Controller:
         self.chunks: list[DataChunk] = []
         self.start_ota_data: StartOtaData = StartOtaData()
         self.transfer_data: dict[str, TransferDataStatus] = {}
+        # OTA protocol version reported per bot in its OTA_START_ACK (1 = legacy
+        # per-chunk, 2 = block/bitmap). Drives the transfer-path choice.
+        self._ota_versions: dict[str, int] = {}
+        # Active block transfer, so RX-thread report/finalize frames can be fed
+        # into it. None outside a block-OTA transfer.
+        self._block_transfer: BlockTransfer | None = None
         self._known_devices: dict[str, StatusType] = {}
         self._log_event_listeners: list = []
         self._log_listeners_lock = threading.Lock()
@@ -552,11 +561,26 @@ class Controller:
                 last_updated_at=now,
             )
             self.status_data.update({device_addr: status})
-        elif (
-            packet.payload_type == PayloadType.SWARMIT_OTA_START_ACK
-            and device_addr not in self.start_ota_data.addrs
-        ):
-            self.start_ota_data.addrs.append(device_addr)
+        elif packet.payload_type == PayloadType.SWARMIT_OTA_START_ACK:
+            # A bootloader speaking the block protocol appends its version; a
+            # legacy one sends the empty ack, which parses as version 1.
+            self._ota_versions[device_addr] = getattr(
+                packet.payload, "version", OTA_PROTOCOL_VERSION_LEGACY
+            )
+            if device_addr not in self.start_ota_data.addrs:
+                self.start_ota_data.addrs.append(device_addr)
+        elif packet.payload_type == PayloadType.SWARMIT_OTA_BLOCK_REPORT_RESP:
+            if self._block_transfer is not None:
+                self._block_transfer.on_report(
+                    device_addr,
+                    packet.payload.block_index,
+                    packet.payload.received_mask,
+                )
+        elif packet.payload_type == PayloadType.SWARMIT_OTA_FINALIZE_RESP:
+            if self._block_transfer is not None:
+                self._block_transfer.on_finalize_resp(
+                    device_addr, bool(packet.payload.ok)
+                )
         elif packet.payload_type == PayloadType.SWARMIT_OTA_CHUNK_ACK:
             try:
                 acked = bool(
@@ -834,7 +858,15 @@ class Controller:
         """Start the OTA process."""
         if devices is None:
             devices = self.settings.devices or []
+        # Pad the image to a 4-byte boundary: the device writes flash a 32-bit
+        # word at a time, so a final chunk whose length is not a multiple of 4
+        # would drop its tail bytes and fail the whole-image FINALIZE check.
+        # 0xFF is the erased-flash value, so the padding is a no-op on device.
+        firmware = bytes(firmware)
+        if len(firmware) % 4:
+            firmware = firmware + b"\xff" * (4 - len(firmware) % 4)
         self.start_ota_data = StartOtaData()
+        self._ota_versions = {}
         self.chunks = []
         digest = hashes.Hash(hashes.SHA256())
         chunks_count = int(len(firmware) / CHUNK_SIZE) + int(
@@ -953,6 +985,83 @@ class Controller:
             time.sleep(0.001)
             send = time.time() - send_time > self.settings.ota_timeout
 
+    def _transfer_block_protocol(
+        self,
+        firmware,
+        devices,
+        show_progress: bool = True,
+    ) -> dict[str, TransferDataStatus]:
+        """Transfer the image with the block / bitmap-NACK protocol.
+
+        Populates ``self.transfer_data`` (acked bits, success) exactly like the
+        legacy path so callers - the daemon stream, LocalSwarmitClient.flash -
+        keep working unchanged.
+        """
+        data_size = len(firmware)
+        use_progress_bar = show_progress and not self.settings.verbose
+        progress = None
+        if use_progress_bar:
+            progress = tqdm(
+                range(0, data_size),
+                unit="B",
+                unit_scale=False,
+                colour="green",
+                ncols=100,
+            )
+            progress.set_description(
+                f"Loading firmware ({int(data_size / 1024)}kB, block OTA)"
+            )
+
+        self.transfer_data = {}
+        for _addr in devices:
+            self.transfer_data[_addr] = TransferDataStatus()
+            self.transfer_data[_addr].chunks = [
+                Chunk(index=f"{i:03d}", size=f"{self.chunks[i].size:03d}B")
+                for i in range(len(self.chunks))
+            ]
+
+        def on_progress(addr: str, chunk_index: int) -> None:
+            td = self.transfer_data.get(addr)
+            if td is None or chunk_index >= len(td.chunks):
+                return
+            chunk = td.chunks[chunk_index]
+            if not chunk.acked:
+                chunk.acked = 1
+                if progress is not None:
+                    progress.update(self.chunks[chunk_index].size)
+
+        broadcast = not self.settings.devices
+        transfer = BlockTransfer(
+            chunks=self.chunks,
+            devices=list(devices),
+            send_payload=self.send_payload,
+            image_sha=self.start_ota_data.fw_hash,
+            settings=BlockOTASettings(),
+            broadcast=broadcast,
+            on_progress=on_progress,
+            logger=self.logger,
+        )
+        self._block_transfer = transfer
+        try:
+            results = transfer.run()
+        finally:
+            self._block_transfer = None
+        if progress is not None:
+            progress.close()
+
+        for addr, result in results.items():
+            td = self.transfer_data.get(addr)
+            if td is not None:
+                td.success = result.success
+        if self.settings.verbose:
+            for addr, result in results.items():
+                print(
+                    f"{addr}: {result.confirmed_chunks}/{result.total_chunks} "
+                    f"chunks, finalized={result.finalized}, "
+                    f"straggler={result.straggler}"
+                )
+        return self.transfer_data
+
     def transfer(
         self,
         firmware,
@@ -965,6 +1074,19 @@ class Controller:
         render their own progress (e.g. the daemon's /flash/stream or
         LocalSwarmitClient.flash) pass False to avoid duplicate output.
         """
+        # Use the block/bitmap path when every target bot negotiated it in its
+        # OTA_START_ACK; otherwise fall back to the legacy per-chunk path for
+        # the whole group. (Per-subset dual-path is a follow-up - see
+        # plans/swarmit-fast-ota/plan.html, Phase 2.)
+        if devices and all(
+            self._ota_versions.get(addr, OTA_PROTOCOL_VERSION_LEGACY)
+            >= OTA_PROTOCOL_VERSION_BLOCK
+            for addr in devices
+        ):
+            return self._transfer_block_protocol(
+                firmware, devices, show_progress
+            )
+
         data_size = len(firmware)
         use_progress_bar = show_progress and not self.settings.verbose
         if use_progress_bar:

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -26,6 +26,7 @@ from swarmit.testbed.adapter import (
 from swarmit.testbed.logger import LOGGER
 from swarmit.testbed.ota import (
     BLOCK_SIZE_DEFAULT,
+    DEVICE_CHUNK_RATE_HZ,
     OTA_DOWNLINK_UTILIZATION,
     BlockTransfer,
     settings_for_fleet,
@@ -1072,7 +1073,12 @@ class Controller:
         utilization = float(
             os.environ.get("SWARMIT_OTA_UTILIZATION", OTA_DOWNLINK_UTILIZATION)
         )
-        settings = settings_for_fleet(schedule, len(devices), utilization)
+        device_rate = float(
+            os.environ.get("SWARMIT_OTA_DEVICE_RATE", DEVICE_CHUNK_RATE_HZ)
+        )
+        settings = settings_for_fleet(
+            schedule, len(devices), utilization, device_rate
+        )
         transfer = BlockTransfer(
             chunks=self.chunks,
             devices=list(devices),

--- a/swarmit/testbed/logger.py
+++ b/swarmit/testbed/logger.py
@@ -7,12 +7,27 @@
 
 import logging
 import logging.config
+import os
+from pathlib import Path
 
 import structlog
 
 
+def log_file_path() -> Path:
+    """Persistent swarmit log file (override with SWARMIT_LOG_FILE)."""
+    override = os.environ.get("SWARMIT_LOG_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".dotbot" / "logs" / "swarmit.log"
+
+
 def setup_logging():
-    """Setup logging."""
+    """Setup logging.
+
+    Logs go to stderr (rich, for the operator) and, when the log directory is
+    writable, are also appended as parseable logfmt lines to
+    ``log_file_path()`` so a flash run can be analysed after the fact.
+    """
     processors = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
@@ -61,6 +76,24 @@ def setup_logging():
             },
         },
     }
+
+    # Best-effort persistent file log (parseable logfmt); never let a
+    # non-writable log dir break the CLI.
+    try:
+        path = log_file_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        stdlib_config["handlers"]["file"] = {
+            "formatter": "logfmt",
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": str(path),
+            "maxBytes": 5_000_000,
+            "backupCount": 3,
+            "mode": "a",
+        }
+        stdlib_config["loggers"]["swarmit"]["handlers"].append("file")
+    except OSError:
+        pass
+
     logging.config.dictConfig(stdlib_config)
 
 

--- a/swarmit/testbed/logger.py
+++ b/swarmit/testbed/logger.py
@@ -62,10 +62,14 @@ def setup_logging():
             },
         },
         "handlers": {
+            # Console stays quiet at INFO so structured logs never clobber the
+            # flash progress bar; the full INFO stream goes to the file handler
+            # below. Warnings and errors still reach the operator.
             "console": {
                 "formatter": "rich",
                 "class": "logging.StreamHandler",
                 "stream": "ext://sys.stderr",
+                "level": "WARNING",
             }
         },
         "loggers": {

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -1,9 +1,8 @@
-"""Block-OTA transfer state machine (fast OTA, Phase 1).
+"""Block-OTA transfer state machine.
 
-The legacy OTA path in ``controller.py`` is a per-chunk stop-and-wait: it
-broadcasts one chunk, waits for every bot to ack it, then moves on. That idles
-the Mari link on a round trip per chunk. This module implements the block /
-bitmap-NACK path instead:
+This replaced a per-chunk stop-and-wait that broadcast one chunk, waited for
+every bot to ack it, then moved on - a round trip per chunk, with the link idle
+in between. Instead:
 
 1. Broadcast a whole block of chunks (``block_size`` of them) with no per-chunk
    ack.
@@ -37,35 +36,24 @@ from typing import Callable, Iterable, Protocol
 from dotbot_utils.protocol import Payload
 
 from swarmit.testbed.protocol import (
+    BROADCAST_ADDRESS,
     PayloadOTABlockReportReq,
     PayloadOTAChunk,
     PayloadOTAFinalize,
 )
 
-BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
-
 # W = 32 is the largest block the uint32 report bitmap holds without a wire
 # change; a larger block means fewer report rounds (less per-block overhead).
 BLOCK_SIZE_DEFAULT = 32
-# Base settle time before collecting a block report (~one Mari slotframe): the
-# fixed part of the wait, on top of the time it takes the block to be delivered.
-REPORT_TIMEOUT_DEFAULT = 0.3
-# Observed per-chunk downlink delivery time. On the desk the gateway delivers
-# ~1 frame per Mari slotframe (~0.26 s/chunk), far below the 22-slots/slotframe
-# theoretical max. The report wait scales by chunks-sent x this, so we wait for a
-# block to actually drain before asking "what did you get?" instead of asking
-# after one slotframe (which made the bot report ~everything missing and
-# triggered a full, wasteful re-send into an already-full gateway queue).
-PER_CHUNK_DELIVERY_DEFAULT = 0.25
-# Upper bound on a single report wait.
-WAIT_CAP_DEFAULT = 12.0
-# Delay between chunk sends. This paces how fast we feed the gateway's ~32-deep
-# TX queue, which is SHARED with status frames and other bots' traffic - so we
-# must not blast a whole block into it. Since the report wait is delivery-aware
-# (below), this delay only moves time from "waiting" into "sending"; it does not
-# slow the transfer (which is drain-bound), it just keeps our queue footprint
-# shallow so other sources keep their slots. Tune from the file log if needed.
-INTER_CHUNK_DELAY_DEFAULT = 0.15
+# How long to collect block reports after a round's sends. Derived from the
+# link geometry by the adapter; this default only applies when a settings
+# object is built by hand (tests).
+REPORT_TIMEOUT_DEFAULT = 0.25
+# Delay between chunk sends, which is what paces the transfer: chunks are
+# injected at the rate the downlink can carry them, so the gateway's shared TX
+# queue stays shallow instead of being blasted a block at a time. Also derived
+# from the link geometry.
+INTER_CHUNK_DELAY_DEFAULT = 0.02
 # A bot that misses this many consecutive report rounds becomes a straggler.
 # Sized against ~90% uplink PDR: P(4 lost reports) = 0.01% per bot-block.
 SILENT_STRAGGLER_ROUNDS_DEFAULT = 4
@@ -88,14 +76,15 @@ def popcount(value: int) -> int:
 class BlockOTASettings:
     """Tunables for the block-OTA state machine.
 
-    Defaults are Mari-"huge"-grounded starting points; per the workspace rules
-    they need >=200-node validation before being declared tuned.
+    ``block_size``, ``inter_chunk_delay`` and ``report_timeout`` normally come
+    from ``adapter.derive_block_settings``, which sizes them against the link
+    the gateway reports. The straggler and round limits below are protocol
+    policy and are the same on any link; per the workspace rules they need
+    >=200-node validation before being called tuned.
     """
 
     block_size: int = BLOCK_SIZE_DEFAULT
     report_timeout: float = REPORT_TIMEOUT_DEFAULT
-    per_chunk_delivery: float = PER_CHUNK_DELIVERY_DEFAULT
-    wait_cap: float = WAIT_CAP_DEFAULT
     inter_chunk_delay: float = INTER_CHUNK_DELAY_DEFAULT
     silent_straggler_rounds: int = SILENT_STRAGGLER_ROUNDS_DEFAULT
     stall_straggler_rounds: int = STALL_STRAGGLER_ROUNDS_DEFAULT
@@ -261,30 +250,6 @@ class BlockTransfer:
         start = block * self._w
         return [start + bit for bit in range(self._w) if mask & (1 << bit)]
 
-    def report_wait(self, chunks_sent: int) -> float:
-        """How long to wait after a round's sends before collecting reports.
-
-        The block needs ``chunks_sent * per_chunk_delivery`` to drain the
-        downlink. The send loop already spent ``chunks_sent * inter_chunk_delay``
-        pacing those sends, during which chunks were draining, so we only wait
-        for the *residual* backlog plus the report-collection window. With
-        ``inter_chunk_delay >= per_chunk_delivery`` (fully paced) the residual is
-        zero and we wait just one report window; with no pacing it reduces to the
-        full drain time. Either way the total per-block time is the same
-        (drain-bound) - pacing only trades wait for send and keeps the gateway
-        queue shallow. A round that sent nothing (a silent-bot re-request) waits
-        just the report window.
-        """
-        if chunks_sent <= 0:
-            return self.settings.report_timeout
-        residual = chunks_sent * max(
-            0.0,
-            self.settings.per_chunk_delivery - self.settings.inter_chunk_delay,
-        )
-        return min(
-            self.settings.report_timeout + residual, self.settings.wait_cap
-        )
-
     # ------------------------------------------------------------------ #
     # RX-thread entry points (thread-safe).
     # ------------------------------------------------------------------ #
@@ -307,19 +272,8 @@ class BlockTransfer:
             self._transfer_block(block)
         self._recover_stragglers()
         self._finalize()
-        results = self._result()
-        # Waste ratio: chunk frames sent vs delivered. ~1.0 is ideal; a high
-        # ratio means the pacing is re-sending chunks the gateway had not yet
-        # drained (tune per_chunk_delivery up toward the real downlink period).
-        delivered = sum(r.confirmed_chunks for r in results.values())
-        if self._logger is not None and delivered:
-            self._logger.info(
-                "block ota done",
-                chunk_sends=self._chunk_sends,
-                delivered=delivered,
-                waste_ratio=round(self._chunk_sends / delivered, 2),
-            )
-        return results
+        # The caller logs the summary (it has the elapsed time to go with it).
+        return self._result()
 
     @property
     def chunk_sends(self) -> int:
@@ -378,7 +332,7 @@ class BlockTransfer:
             PayloadOTABlockReportReq(block_index=block, block_size=self._w),
         )
 
-    def _reset_block_state(self, block: int) -> None:
+    def _reset_block_state(self) -> None:
         self._round = 0
         self._reported = set()
         for addr in self.devices:
@@ -402,7 +356,7 @@ class BlockTransfer:
                     self._on_progress(addr, start + bit)
 
     def _transfer_block(self, block: int) -> None:
-        self._reset_block_state(block)
+        self._reset_block_state()
         needed = set(self.block_chunk_indices(block))
         while True:
             with self._lock:
@@ -414,7 +368,7 @@ class BlockTransfer:
                     self._send_chunks(needed, target)
                     sent_this_round += len(needed)
                 self._send_report_req(block, target)
-            self._sleep(self.report_wait(sent_this_round))
+            self._sleep(self.settings.report_timeout)
             self._evaluate_round(block)
             settled = self.block_settled(block)
             self._log(
@@ -525,18 +479,25 @@ class BlockTransfer:
             self._apply_confirmed(addr, block, mask & self.full_block_mask(block))
 
     def _finalize(self) -> None:
-        targets = list(self.devices)
+        """Ask each device to verify the whole image against its SHA256."""
         for _ in range(self.settings.finalize_max_rounds):
             pending = [
                 addr
-                for addr in targets
+                for addr in self.devices
                 if not self._finalize_inbox.get(addr, False)
             ]
             if not pending:
                 break
-            self._send_payload(
-                self._dest(None), PayloadOTAFinalize(sha=self.image_sha)
-            )
+            payload = PayloadOTAFinalize(sha=self.image_sha)
+            if self.broadcast and len(pending) == len(self.devices):
+                # Everyone still needs it: one frame instead of N.
+                self._send_payload(self._dest(None), payload)
+            else:
+                # Targeted transfer, or a retry for a subset. Asking the whole
+                # network would make untargeted bots hash their own (unrelated)
+                # flash and answer about it.
+                for addr in pending:
+                    self._send_payload(self._dest(addr), payload)
             self._sleep(self.settings.report_timeout)
 
     def _result(self) -> dict[str, DeviceResult]:

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -100,6 +100,84 @@ class BlockOTASettings:
     max_rounds_per_block: int = MAX_ROUNDS_PER_BLOCK_DEFAULT
 
 
+@dataclass(frozen=True)
+class MariSchedule:
+    """Geometry of a Mari schedule - the source of truth for OTA pacing.
+
+    A gateway transmits one downlink frame per D-cell per slotframe, and each
+    joined node gets one uplink cell per slotframe (so all nodes can report
+    within a single slotframe). These two facts drive the whole pacing model.
+    Cell counts from mari/firmware/mari/all_schedules.c.
+    """
+
+    name: str
+    n_slots: int
+    d_cells: int
+    u_cells: int
+    max_nodes: int
+    slot_s: float = 0.00178  # MARI_WHOLE_SLOT_DURATION (~1.78 ms)
+
+    @property
+    def slotframe_s(self) -> float:
+        return self.n_slots * self.slot_s
+
+    @property
+    def downlink_pps(self) -> float:
+        """Gateway downlink capacity in frames/s (all D-cells packed)."""
+        return self.d_cells / self.slotframe_s
+
+
+MARI_SCHEDULES: dict[str, "MariSchedule"] = {
+    "tiny": MariSchedule("tiny", 17, 2, 10, 10),
+    "medium": MariSchedule("medium", 67, 10, 44, 44),
+    "big": MariSchedule("big", 101, 16, 66, 66),
+    "huge": MariSchedule("huge", 149, 22, 102, 102),
+}
+
+# Share of the gateway's downlink slots OTA may drive once it is fast enough to
+# be radio-bound. NOT the binding constraint today - see DEVICE_CHUNK_RATE_HZ.
+OTA_DOWNLINK_UTILIZATION = 0.5
+
+# THE FLIP KNOB. The netcore->bootloader OTA path is single-buffered today, so
+# clean chunk writes top out at ~12/s and pacing must stay well under it; this
+# is the conservative rate validated churn-free on hardware (~150 ms/chunk, the
+# 464-chunk image in ~137 s, waste ~1.1). Raise this toward the radio rate
+# (schedule downlink_pps) once the inter-core chunk ring lands in firmware - at
+# which point the schedule geometry above starts to bind and the report/delivery
+# model needs re-tuning (plan Phase C).
+DEVICE_CHUNK_RATE_HZ = 6.7
+
+
+def settings_for_fleet(
+    schedule: str = "medium",
+    n_bots: int = 1,
+    utilization: float = OTA_DOWNLINK_UTILIZATION,
+    device_chunk_rate: float = DEVICE_CHUNK_RATE_HZ,
+) -> "BlockOTASettings":
+    """Derive block-OTA pacing from the Mari schedule, the device, and fleet size.
+
+    - inject rate = min(radio downlink x utilization, device chunk-write rate).
+      We broadcast, so one frame reaches every bot - the radio term is
+      independent of fleet size. The device term binds today.
+    - report window = a couple of slotframes (every bot reports within one),
+      growing gently as the fleet fills the uplink.
+
+    ``per_chunk_delivery`` is the conservative, HIL-validated churn-free delivery
+    estimate; it (and the report model generally) is deliberately not aggressive
+    and will be re-derived once the firmware ring raises the device rate.
+    """
+    sched = MARI_SCHEDULES.get(schedule, MARI_SCHEDULES["medium"])
+    inject_pps = max(1.0, min(sched.downlink_pps * utilization, device_chunk_rate))
+    report_slotframes = 2.0 + max(0, n_bots - 1) / max(1, sched.u_cells)
+    return BlockOTASettings(
+        block_size=BLOCK_SIZE_DEFAULT,
+        inter_chunk_delay=1.0 / inject_pps,
+        per_chunk_delivery=PER_CHUNK_DELIVERY_DEFAULT,
+        report_timeout=sched.slotframe_s * report_slotframes,
+        wait_cap=WAIT_CAP_DEFAULT,
+    )
+
+
 class ChunkLike(Protocol):
     """Minimal shape the transfer needs from a chunk (controller.DataChunk)."""
 

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -165,6 +165,7 @@ class BlockTransfer:
         sleep: Callable[[float], None] = time.sleep,
         on_progress: Callable[[str, int], None] | None = None,
         logger=None,
+        drop_chunks: Iterable[int] | None = None,
     ):
         self.chunks = list(chunks)
         self.devices = list(devices)
@@ -173,6 +174,9 @@ class BlockTransfer:
         self.settings = settings or BlockOTASettings()
         self.broadcast = broadcast
         self._sleep = sleep
+        # Test hook: chunk indices to never transmit, simulating permanent loss
+        # (proves the finalize SHA catches a genuinely incomplete image).
+        self._drop_chunks = set(drop_chunks or ())
         self._on_progress = on_progress
         self._logger = logger
 
@@ -348,6 +352,8 @@ class BlockTransfer:
     def _send_chunks(self, indices: Iterable[int], addr: str | None) -> None:
         dest = self._dest(addr)
         for idx in sorted(indices):
+            if idx in self._drop_chunks:
+                continue
             chunk = self.chunks[idx]
             self._send_payload(
                 dest,

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -1,0 +1,450 @@
+"""Block-OTA transfer state machine (fast OTA, Phase 1).
+
+The legacy OTA path in ``controller.py`` is a per-chunk stop-and-wait: it
+broadcasts one chunk, waits for every bot to ack it, then moves on. That idles
+the Mari link on a round trip per chunk. This module implements the block /
+bitmap-NACK path instead:
+
+1. Broadcast a whole block of chunks (``block_size`` of them) with no per-chunk
+   ack.
+2. Broadcast one report request; each bot replies with a bitmap of the chunks it
+   received and SHA-verified for that block.
+3. Re-broadcast only the union of still-missing chunks, back off, repeat.
+4. Advance to the next block once every tracked bot reports the whole block.
+5. After the last block, verify each bot's whole-image SHA256 (FINALIZE).
+
+The class is deliberately transport- and clock-injected so it can be unit
+tested with a fake transport and zero real time: ``send_payload``, ``clock`` and
+``sleep`` are all parameters. ``on_report`` / ``on_finalize_resp`` are fed from
+the controller's RX thread (or a test), guarded by a lock.
+
+Reference: BLE Mesh DFU BLOB Transfer (Push mode) for the block/bitmap shape,
+RFC 9177 (CoAP Q-Block) for burst pacing and exponential backoff. Design and
+rationale live in ``plans/swarmit-fast-ota/plan.html``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Protocol
+
+from dotbot_utils.protocol import Payload
+
+from swarmit.testbed.protocol import (
+    PayloadOTABlockReportReq,
+    PayloadOTAChunk,
+    PayloadOTAFinalize,
+)
+
+BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
+
+# W = 22 matches the 22 downlink slots per Mari "huge" slotframe; the report
+# bitmap is a uint32 so W may grow to 32 without a wire change.
+BLOCK_SIZE_DEFAULT = 22
+# One Mari "huge" slotframe (~257 ms); every dedicated uplink slot happens
+# within one slotframe, so any bot that is going to report has reported by then.
+REPORT_TIMEOUT_DEFAULT = 0.26
+BACKOFF_CAP_DEFAULT = 2.0
+# ~ one D-slot cadence on "huge"; a controller-side floor so a denser schedule
+# cannot outrun the bootloader's flash writes.
+INTER_CHUNK_DELAY_DEFAULT = 0.012
+# A bot that misses this many consecutive report rounds becomes a straggler.
+# Sized against ~90% uplink PDR: P(4 lost reports) = 0.01% per bot-block.
+SILENT_STRAGGLER_ROUNDS_DEFAULT = 4
+# A bot whose own missing set stops shrinking for this many rounds is stuck.
+STALL_STRAGGLER_ROUNDS_DEFAULT = 3
+# Bounded unicast recovery rounds for a straggler before FINALIZE.
+STRAGGLER_MAX_ROUNDS_DEFAULT = 4
+# Whole-image verification attempts.
+FINALIZE_MAX_ROUNDS_DEFAULT = 4
+# Hard per-block safety net so a logic bug can never spin forever.
+MAX_ROUNDS_PER_BLOCK_DEFAULT = 32
+
+
+def popcount(value: int) -> int:
+    """Number of set bits."""
+    return bin(value).count("1")
+
+
+@dataclass
+class BlockOTASettings:
+    """Tunables for the block-OTA state machine.
+
+    Defaults are Mari-"huge"-grounded starting points; per the workspace rules
+    they need >=200-node validation before being declared tuned.
+    """
+
+    block_size: int = BLOCK_SIZE_DEFAULT
+    report_timeout: float = REPORT_TIMEOUT_DEFAULT
+    backoff_cap: float = BACKOFF_CAP_DEFAULT
+    inter_chunk_delay: float = INTER_CHUNK_DELAY_DEFAULT
+    silent_straggler_rounds: int = SILENT_STRAGGLER_ROUNDS_DEFAULT
+    stall_straggler_rounds: int = STALL_STRAGGLER_ROUNDS_DEFAULT
+    straggler_max_rounds: int = STRAGGLER_MAX_ROUNDS_DEFAULT
+    finalize_max_rounds: int = FINALIZE_MAX_ROUNDS_DEFAULT
+    max_rounds_per_block: int = MAX_ROUNDS_PER_BLOCK_DEFAULT
+
+
+class ChunkLike(Protocol):
+    """Minimal shape the transfer needs from a chunk (controller.DataChunk)."""
+
+    index: int
+    size: int
+    sha: bytes
+    data: bytes
+
+
+@dataclass
+class DeviceResult:
+    """Per-device outcome of a block-OTA transfer."""
+
+    confirmed_chunks: int = 0
+    total_chunks: int = 0
+    straggler: bool = False
+    finalized: bool = False
+
+    @property
+    def success(self) -> bool:
+        return self.finalized and self.confirmed_chunks == self.total_chunks
+
+
+class BlockTransfer:
+    """Drive one block-OTA image transfer to a set of devices.
+
+    Parameters
+    ----------
+    chunks:
+        ordered chunks of the image (objects with ``index/size/sha/data``).
+    devices:
+        device address strings (hex, as the controller formats them).
+    send_payload:
+        ``send_payload(destination:int, payload)`` - the transport.
+    image_sha:
+        32-byte SHA256 of the whole image, sent in FINALIZE.
+    settings:
+        :class:`BlockOTASettings`.
+    broadcast:
+        send chunks/report-reqs to the broadcast address (the common case) vs
+        per-device unicast.
+    sleep:
+        injected delay, so tests run without real time.
+    on_progress:
+        optional ``on_progress(addr, chunk_index)`` fired as chunks are
+        confirmed; the controller uses it to drive its progress bar.
+    """
+
+    def __init__(
+        self,
+        chunks: list[ChunkLike],
+        devices: Iterable[str],
+        send_payload: Callable[[int, Payload], None],
+        image_sha: bytes,
+        settings: BlockOTASettings | None = None,
+        broadcast: bool = True,
+        sleep: Callable[[float], None] = time.sleep,
+        on_progress: Callable[[str, int], None] | None = None,
+        logger=None,
+    ):
+        self.chunks = list(chunks)
+        self.devices = list(devices)
+        self._send_payload = send_payload
+        self.image_sha = bytes(image_sha)
+        self.settings = settings or BlockOTASettings()
+        self.broadcast = broadcast
+        self._sleep = sleep
+        self._on_progress = on_progress
+        self._logger = logger
+
+        self._w = self.settings.block_size
+        self.num_blocks = (len(self.chunks) + self._w - 1) // self._w
+
+        self._lock = threading.Lock()
+        # Reports collected during the current round: addr -> (block, mask).
+        self._round_reports: dict[str, tuple[int, int]] = {}
+        # Finalize responses: addr -> ok(bool).
+        self._finalize_inbox: dict[str, bool] = {}
+
+        # Persistent per-(device, block) confirmed bitmap.
+        self._confirmed: dict[tuple[str, int], int] = {}
+        # Straggler set (reversible: a bot rejoins when it reports again).
+        self._straggler: set[str] = set()
+        # Blocks each device never fully confirmed (for the unicast pass).
+        self._incomplete: dict[str, set[int]] = {addr: set() for addr in self.devices}
+
+        # Transient per-block counters, reset in _reset_block_state.
+        self._silent: dict[str, int] = {}
+        self._stall: dict[str, int] = {}
+        self._last_missing: dict[str, int | None] = {}
+        # Devices that have sent at least one report for the current block.
+        self._reported: set[str] = set()
+        self._round = 0
+
+    # ------------------------------------------------------------------ #
+    # Pure helpers (no I/O) - the unit-test surface.
+    # ------------------------------------------------------------------ #
+    def block_chunk_indices(self, block: int) -> range:
+        """Absolute chunk indices belonging to ``block``."""
+        start = block * self._w
+        end = min(start + self._w, len(self.chunks))
+        return range(start, end)
+
+    def full_block_mask(self, block: int) -> int:
+        """Bitmask with one bit per chunk present in ``block``."""
+        return (1 << len(self.block_chunk_indices(block))) - 1
+
+    def confirmed_mask(self, addr: str, block: int) -> int:
+        return self._confirmed.get((addr, block), 0)
+
+    def device_clean(self, addr: str, block: int) -> bool:
+        """True if ``addr`` has confirmed every chunk of ``block``."""
+        return self.confirmed_mask(addr, block) == self.full_block_mask(block)
+
+    def repair_mask(self, block: int) -> int:
+        """Chunks to re-broadcast this round.
+
+        Union of what each *reporting*, non-clean, non-straggler device is still
+        missing. A silent bot contributes nothing - it gets another report
+        request, not a data retransmit - so one lost report costs a round, never
+        a whole re-sent block.
+        """
+        full = self.full_block_mask(block)
+        missing = 0
+        for addr in self.devices:
+            if addr not in self._reported:
+                continue
+            if self.device_clean(addr, block) or addr in self._straggler:
+                continue
+            missing |= full & ~self.confirmed_mask(addr, block)
+        return missing
+
+    def block_settled(self, block: int) -> bool:
+        """True once every device is either clean or a straggler for block."""
+        return all(
+            self.device_clean(addr, block) or addr in self._straggler
+            for addr in self.devices
+        )
+
+    def indices_from_mask(self, block: int, mask: int) -> list[int]:
+        """Absolute chunk indices selected by ``mask`` within ``block``."""
+        start = block * self._w
+        return [start + bit for bit in range(self._w) if mask & (1 << bit)]
+
+    def round_wait(self, round_no: int) -> float:
+        """Exponential backoff on the report-collection window."""
+        return min(
+            self.settings.report_timeout * (2**round_no),
+            self.settings.backoff_cap,
+        )
+
+    # ------------------------------------------------------------------ #
+    # RX-thread entry points (thread-safe).
+    # ------------------------------------------------------------------ #
+    def on_report(self, addr: str, block_index: int, received_mask: int) -> None:
+        """Feed a BLOCK_REPORT_RESP into the current round (RX thread)."""
+        with self._lock:
+            self._round_reports[addr] = (block_index, received_mask)
+
+    def on_finalize_resp(self, addr: str, ok: bool) -> None:
+        """Feed an OTA_FINALIZE_RESP (RX thread)."""
+        with self._lock:
+            self._finalize_inbox[addr] = bool(ok)
+
+    # ------------------------------------------------------------------ #
+    # Driver.
+    # ------------------------------------------------------------------ #
+    def run(self) -> dict[str, DeviceResult]:
+        """Transfer the whole image and return per-device results."""
+        for block in range(self.num_blocks):
+            self._transfer_block(block)
+        self._recover_stragglers()
+        self._finalize()
+        return self._result()
+
+    def _dest(self, addr: str | None) -> int:
+        if addr is None:
+            return BROADCAST_ADDRESS
+        return int(addr, 16)
+
+    def _send_chunks(self, indices: Iterable[int], addr: str | None) -> None:
+        dest = self._dest(addr)
+        for idx in sorted(indices):
+            chunk = self.chunks[idx]
+            self._send_payload(
+                dest,
+                PayloadOTAChunk(
+                    index=chunk.index,
+                    count=chunk.size,
+                    sha=chunk.sha,
+                    chunk=chunk.data,
+                ),
+            )
+            if self.settings.inter_chunk_delay:
+                self._sleep(self.settings.inter_chunk_delay)
+
+    def _send_report_req(self, block: int, addr: str | None) -> None:
+        self._send_payload(
+            self._dest(addr),
+            PayloadOTABlockReportReq(block_index=block, block_size=self._w),
+        )
+
+    def _reset_block_state(self, block: int) -> None:
+        self._round = 0
+        self._reported = set()
+        for addr in self.devices:
+            self._silent[addr] = 0
+            self._stall[addr] = 0
+            self._last_missing[addr] = None
+
+    def _apply_confirmed(self, addr: str, block: int, got: int) -> None:
+        """Merge newly reported bits, firing on_progress for fresh chunks."""
+        key = (addr, block)
+        prev = self._confirmed.get(key, 0)
+        merged = prev | got
+        if merged == prev:
+            return
+        self._confirmed[key] = merged
+        if self._on_progress is not None:
+            fresh = merged & ~prev
+            start = block * self._w
+            for bit in range(self._w):
+                if fresh & (1 << bit):
+                    self._on_progress(addr, start + bit)
+
+    def _transfer_block(self, block: int) -> None:
+        self._reset_block_state(block)
+        needed = set(self.block_chunk_indices(block))
+        while True:
+            with self._lock:
+                self._round_reports = {}
+            targets = [None] if self.broadcast else list(self.devices)
+            for target in targets:
+                if needed:
+                    self._send_chunks(needed, target)
+                self._send_report_req(block, target)
+            self._sleep(self.round_wait(self._round))
+            self._evaluate_round(block)
+            if self.block_settled(block):
+                break
+            needed = set(
+                self.indices_from_mask(block, self.repair_mask(block))
+            )
+            self._round += 1
+            if self._round >= self.settings.max_rounds_per_block:
+                break
+        # Record blocks this device never completed for the unicast pass.
+        for addr in self.devices:
+            if not self.device_clean(addr, block):
+                self._incomplete[addr].add(block)
+
+    def _evaluate_round(self, block: int) -> None:
+        with self._lock:
+            reports = dict(self._round_reports)
+        full = self.full_block_mask(block)
+        for addr in self.devices:
+            if self.device_clean(addr, block):
+                continue
+            rep = reports.get(addr)
+            if rep is None:
+                self._silent[addr] += 1
+                if self._silent[addr] >= self.settings.silent_straggler_rounds:
+                    self._straggler.add(addr)
+                continue
+            # The device reported this round: reset silence, allow rejoin.
+            self._silent[addr] = 0
+            self._reported.add(addr)
+            self._straggler.discard(addr)
+            reported_block, mask = rep
+            if reported_block == block:
+                got = mask & full
+            elif reported_block < block:
+                got = 0  # device has not started this block yet
+            else:
+                got = full  # already past this block
+            self._apply_confirmed(addr, block, got)
+            missing = full & ~self.confirmed_mask(addr, block)
+            if missing == 0:
+                self._stall[addr] = 0
+                continue
+            missing_count = popcount(missing)
+            last = self._last_missing[addr]
+            if last is not None and missing_count >= last:
+                self._stall[addr] += 1
+            else:
+                self._stall[addr] = 0
+            self._last_missing[addr] = missing_count
+            if self._stall[addr] >= self.settings.stall_straggler_rounds:
+                self._straggler.add(addr)
+
+    def _recover_stragglers(self) -> None:
+        """Bounded per-bot unicast repair for blocks left incomplete."""
+        for addr in self.devices:
+            for _ in range(self.settings.straggler_max_rounds):
+                blocks = sorted(
+                    b
+                    for b in self._incomplete.get(addr, set())
+                    if not self.device_clean(addr, b)
+                )
+                if not blocks:
+                    break
+                for block in blocks:
+                    missing = self.full_block_mask(block) & ~self.confirmed_mask(
+                        addr, block
+                    )
+                    with self._lock:
+                        self._round_reports = {}
+                    self._send_chunks(
+                        self.indices_from_mask(block, missing), addr
+                    )
+                    self._send_report_req(block, addr)
+                    self._sleep(self.settings.report_timeout)
+                    self._evaluate_unicast(addr, block)
+            # Refresh incomplete set after the pass.
+            self._incomplete[addr] = {
+                b
+                for b in self._incomplete.get(addr, set())
+                if not self.device_clean(addr, b)
+            }
+
+    def _evaluate_unicast(self, addr: str, block: int) -> None:
+        with self._lock:
+            rep = self._round_reports.get(addr)
+        if rep is None:
+            return
+        reported_block, mask = rep
+        if reported_block == block:
+            self._straggler.discard(addr)
+            self._apply_confirmed(addr, block, mask & self.full_block_mask(block))
+
+    def _finalize(self) -> None:
+        targets = list(self.devices)
+        for _ in range(self.settings.finalize_max_rounds):
+            pending = [
+                addr
+                for addr in targets
+                if not self._finalize_inbox.get(addr, False)
+            ]
+            if not pending:
+                break
+            self._send_payload(
+                self._dest(None), PayloadOTAFinalize(sha=self.image_sha)
+            )
+            self._sleep(self.settings.report_timeout)
+
+    def _result(self) -> dict[str, DeviceResult]:
+        total = len(self.chunks)
+        results: dict[str, DeviceResult] = {}
+        for addr in self.devices:
+            confirmed = sum(
+                popcount(self.confirmed_mask(addr, block))
+                for block in range(self.num_blocks)
+            )
+            results[addr] = DeviceResult(
+                confirmed_chunks=confirmed,
+                total_chunks=total,
+                straggler=addr in self._straggler
+                or bool(self._incomplete.get(addr)),
+                finalized=self._finalize_inbox.get(addr, False),
+            )
+        return results

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -138,14 +138,14 @@ MARI_SCHEDULES: dict[str, "MariSchedule"] = {
 # be radio-bound. NOT the binding constraint today - see DEVICE_CHUNK_RATE_HZ.
 OTA_DOWNLINK_UTILIZATION = 0.5
 
-# THE FLIP KNOB. The netcore->bootloader OTA path is single-buffered today, so
-# clean chunk writes top out at ~12/s and pacing must stay well under it; this
-# is the conservative rate validated churn-free on hardware (~150 ms/chunk, the
-# 464-chunk image in ~137 s, waste ~1.1). Raise this toward the radio rate
-# (schedule downlink_pps) once the inter-core chunk ring lands in firmware - at
-# which point the schedule geometry above starts to bind and the report/delivery
-# model needs re-tuning (plan Phase C).
-DEVICE_CHUNK_RATE_HZ = 6.7
+# Device chunk-write ceiling. Once the firmware stopped acking every chunk (the
+# per-chunk uplink ack was throttling the transfer to the node's one uplink cell
+# per slotframe) and the shared chunk buffer read was guarded, the device
+# handles the full radio rate cleanly on hardware - a 12 ms/chunk (~84/s) inject
+# flashes the 464-chunk image in ~24 s (was ~137 s), finalize OK. So this is now
+# the radio rate, not the old ~6.7 single-buffer clamp; the schedule geometry
+# above (downlink_pps x utilization) is what actually binds.
+DEVICE_CHUNK_RATE_HZ = 84.0
 
 
 def settings_for_fleet(
@@ -168,11 +168,16 @@ def settings_for_fleet(
     """
     sched = MARI_SCHEDULES.get(schedule, MARI_SCHEDULES["medium"])
     inject_pps = max(1.0, min(sched.downlink_pps * utilization, device_chunk_rate))
+    inter_chunk = 1.0 / inject_pps
     report_slotframes = 2.0 + max(0, n_bots - 1) / max(1, sched.u_cells)
     return BlockOTASettings(
         block_size=BLOCK_SIZE_DEFAULT,
-        inter_chunk_delay=1.0 / inject_pps,
-        per_chunk_delivery=PER_CHUNK_DELIVERY_DEFAULT,
+        inter_chunk_delay=inter_chunk,
+        # We pace injection at the delivery rate, so a block drains as it is sent
+        # and the report wait only needs the collection window - no big residual.
+        # (With the pre-firmware per-chunk-ack path the device could not keep up
+        # and this needed a long drain margin; the ring/no-ack fix removes that.)
+        per_chunk_delivery=inter_chunk,
         report_timeout=sched.slotframe_s * report_slotframes,
         wait_cap=WAIT_CAP_DEFAULT,
     )

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -43,12 +43,20 @@ BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 # W = 22 matches the 22 downlink slots per Mari "huge" slotframe; the report
 # bitmap is a uint32 so W may grow to 32 without a wire change.
 BLOCK_SIZE_DEFAULT = 22
-# One Mari "huge" slotframe (~257 ms); every dedicated uplink slot happens
-# within one slotframe, so any bot that is going to report has reported by then.
-REPORT_TIMEOUT_DEFAULT = 0.26
-BACKOFF_CAP_DEFAULT = 2.0
-# ~ one D-slot cadence on "huge"; a controller-side floor so a denser schedule
-# cannot outrun the bootloader's flash writes.
+# Base settle time before collecting a block report (~one Mari slotframe): the
+# fixed part of the wait, on top of the time it takes the block to be delivered.
+REPORT_TIMEOUT_DEFAULT = 0.3
+# Observed per-chunk downlink delivery time. On the desk the gateway delivers
+# ~1 frame per Mari slotframe (~0.26 s/chunk), far below the 22-slots/slotframe
+# theoretical max. The report wait scales by chunks-sent x this, so we wait for a
+# block to actually drain before asking "what did you get?" instead of asking
+# after one slotframe (which made the bot report ~everything missing and
+# triggered a full, wasteful re-send into an already-full gateway queue).
+PER_CHUNK_DELIVERY_DEFAULT = 0.25
+# Upper bound on a single report wait.
+WAIT_CAP_DEFAULT = 12.0
+# Controller-side floor between chunk sends; small, since the gateway's ~32-deep
+# queue buffers a W=22 block. The real pacing is the report wait above.
 INTER_CHUNK_DELAY_DEFAULT = 0.012
 # A bot that misses this many consecutive report rounds becomes a straggler.
 # Sized against ~90% uplink PDR: P(4 lost reports) = 0.01% per bot-block.
@@ -78,7 +86,8 @@ class BlockOTASettings:
 
     block_size: int = BLOCK_SIZE_DEFAULT
     report_timeout: float = REPORT_TIMEOUT_DEFAULT
-    backoff_cap: float = BACKOFF_CAP_DEFAULT
+    per_chunk_delivery: float = PER_CHUNK_DELIVERY_DEFAULT
+    wait_cap: float = WAIT_CAP_DEFAULT
     inter_chunk_delay: float = INTER_CHUNK_DELAY_DEFAULT
     silent_straggler_rounds: int = SILENT_STRAGGLER_ROUNDS_DEFAULT
     stall_straggler_rounds: int = STALL_STRAGGLER_ROUNDS_DEFAULT
@@ -168,6 +177,9 @@ class BlockTransfer:
 
         # Persistent per-(device, block) confirmed bitmap.
         self._confirmed: dict[tuple[str, int], int] = {}
+        # Total chunk frames put on the wire (incl. retransmits). Compared with
+        # the delivered count it exposes wasted downlink (churn).
+        self._chunk_sends = 0
         # Straggler set (reversible: a bot rejoins when it reports again).
         self._straggler: set[str] = set()
         # Blocks each device never fully confirmed (for the unicast pass).
@@ -231,11 +243,19 @@ class BlockTransfer:
         start = block * self._w
         return [start + bit for bit in range(self._w) if mask & (1 << bit)]
 
-    def round_wait(self, round_no: int) -> float:
-        """Exponential backoff on the report-collection window."""
+    def report_wait(self, chunks_sent: int) -> float:
+        """How long to wait before collecting reports for a round.
+
+        Scales with the number of chunks just sent, so a full block gets time to
+        actually drain the downlink before we ask what landed, while a small
+        repair round waits only briefly. This is what keeps the bot from
+        reporting a block ~empty one slotframe after a 22-chunk burst and
+        triggering a wasteful full re-send.
+        """
         return min(
-            self.settings.report_timeout * (2**round_no),
-            self.settings.backoff_cap,
+            self.settings.report_timeout
+            + chunks_sent * self.settings.per_chunk_delivery,
+            self.settings.wait_cap,
         )
 
     # ------------------------------------------------------------------ #
@@ -260,7 +280,23 @@ class BlockTransfer:
             self._transfer_block(block)
         self._recover_stragglers()
         self._finalize()
-        return self._result()
+        results = self._result()
+        # Waste ratio: chunk frames sent vs delivered. ~1.0 is ideal; a high
+        # ratio means the pacing is re-sending chunks the gateway had not yet
+        # drained (tune per_chunk_delivery up toward the real downlink period).
+        delivered = sum(r.confirmed_chunks for r in results.values())
+        if self._logger is not None and delivered:
+            self._logger.info(
+                "block ota done",
+                chunk_sends=self._chunk_sends,
+                delivered=delivered,
+                waste_ratio=round(self._chunk_sends / delivered, 2),
+            )
+        return results
+
+    @property
+    def chunk_sends(self) -> int:
+        return self._chunk_sends
 
     def _dest(self, addr: str | None) -> int:
         if addr is None:
@@ -280,6 +316,7 @@ class BlockTransfer:
                     chunk=chunk.data,
                 ),
             )
+            self._chunk_sends += 1
             if self.settings.inter_chunk_delay:
                 self._sleep(self.settings.inter_chunk_delay)
 
@@ -319,11 +356,13 @@ class BlockTransfer:
             with self._lock:
                 self._round_reports = {}
             targets = [None] if self.broadcast else list(self.devices)
+            sent_this_round = 0
             for target in targets:
                 if needed:
                     self._send_chunks(needed, target)
+                    sent_this_round += len(needed)
                 self._send_report_req(block, target)
-            self._sleep(self.round_wait(self._round))
+            self._sleep(self.report_wait(sent_this_round))
             self._evaluate_round(block)
             if self.block_settled(block):
                 break

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -319,6 +319,21 @@ class BlockTransfer:
         """Total chunks confirmed across all (device, block) so far."""
         return sum(popcount(mask) for mask in self._confirmed.values())
 
+    def missing_chunks(self, addr: str) -> list[int]:
+        """Absolute chunk indices this device has not confirmed."""
+        missing = []
+        for block in range(self.num_blocks):
+            full = self.full_block_mask(block)
+            got = self.confirmed_mask(addr, block)
+            gap = full & ~got
+            if not gap:
+                continue
+            start = block * self._w
+            for bit in range(self._w):
+                if gap & (1 << bit):
+                    missing.append(start + bit)
+        return missing
+
     def _dest(self, addr: str | None) -> int:
         if addr is None:
             return BROADCAST_ADDRESS

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -298,6 +298,14 @@ class BlockTransfer:
     def chunk_sends(self) -> int:
         return self._chunk_sends
 
+    def _log(self, event: str, **fields) -> None:
+        if self._logger is not None:
+            self._logger.info(event, **fields)
+
+    def _delivered_total(self) -> int:
+        """Total chunks confirmed across all (device, block) so far."""
+        return sum(popcount(mask) for mask in self._confirmed.values())
+
     def _dest(self, addr: str | None) -> int:
         if addr is None:
             return BROADCAST_ADDRESS
@@ -364,7 +372,16 @@ class BlockTransfer:
                 self._send_report_req(block, target)
             self._sleep(self.report_wait(sent_this_round))
             self._evaluate_round(block)
-            if self.block_settled(block):
+            settled = self.block_settled(block)
+            self._log(
+                "block round",
+                block=block,
+                round=self._round,
+                sent=sent_this_round,
+                delivered=self._delivered_total(),
+                settled=settled,
+            )
+            if settled:
                 break
             needed = set(
                 self.indices_from_mask(block, self.repair_mask(block))
@@ -376,6 +393,13 @@ class BlockTransfer:
         for addr in self.devices:
             if not self.device_clean(addr, block):
                 self._incomplete[addr].add(block)
+        self._log(
+            "block done",
+            block=block,
+            rounds=self._round + 1,
+            sends=self._chunk_sends,
+            delivered=self._delivered_total(),
+        )
 
     def _evaluate_round(self, block: int) -> None:
         with self._lock:

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -40,9 +40,9 @@ from swarmit.testbed.protocol import (
 
 BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 
-# W = 22 matches the 22 downlink slots per Mari "huge" slotframe; the report
-# bitmap is a uint32 so W may grow to 32 without a wire change.
-BLOCK_SIZE_DEFAULT = 22
+# W = 32 is the largest block the uint32 report bitmap holds without a wire
+# change; a larger block means fewer report rounds (less per-block overhead).
+BLOCK_SIZE_DEFAULT = 32
 # Base settle time before collecting a block report (~one Mari slotframe): the
 # fixed part of the wait, on top of the time it takes the block to be delivered.
 REPORT_TIMEOUT_DEFAULT = 0.3
@@ -55,9 +55,13 @@ REPORT_TIMEOUT_DEFAULT = 0.3
 PER_CHUNK_DELIVERY_DEFAULT = 0.25
 # Upper bound on a single report wait.
 WAIT_CAP_DEFAULT = 12.0
-# Controller-side floor between chunk sends; small, since the gateway's ~32-deep
-# queue buffers a W=22 block. The real pacing is the report wait above.
-INTER_CHUNK_DELAY_DEFAULT = 0.012
+# Delay between chunk sends. This paces how fast we feed the gateway's ~32-deep
+# TX queue, which is SHARED with status frames and other bots' traffic - so we
+# must not blast a whole block into it. Since the report wait is delivery-aware
+# (below), this delay only moves time from "waiting" into "sending"; it does not
+# slow the transfer (which is drain-bound), it just keeps our queue footprint
+# shallow so other sources keep their slots. Tune from the file log if needed.
+INTER_CHUNK_DELAY_DEFAULT = 0.15
 # A bot that misses this many consecutive report rounds becomes a straggler.
 # Sized against ~90% uplink PDR: P(4 lost reports) = 0.01% per bot-block.
 SILENT_STRAGGLER_ROUNDS_DEFAULT = 4
@@ -244,18 +248,27 @@ class BlockTransfer:
         return [start + bit for bit in range(self._w) if mask & (1 << bit)]
 
     def report_wait(self, chunks_sent: int) -> float:
-        """How long to wait before collecting reports for a round.
+        """How long to wait after a round's sends before collecting reports.
 
-        Scales with the number of chunks just sent, so a full block gets time to
-        actually drain the downlink before we ask what landed, while a small
-        repair round waits only briefly. This is what keeps the bot from
-        reporting a block ~empty one slotframe after a 22-chunk burst and
-        triggering a wasteful full re-send.
+        The block needs ``chunks_sent * per_chunk_delivery`` to drain the
+        downlink. The send loop already spent ``chunks_sent * inter_chunk_delay``
+        pacing those sends, during which chunks were draining, so we only wait
+        for the *residual* backlog plus the report-collection window. With
+        ``inter_chunk_delay >= per_chunk_delivery`` (fully paced) the residual is
+        zero and we wait just one report window; with no pacing it reduces to the
+        full drain time. Either way the total per-block time is the same
+        (drain-bound) - pacing only trades wait for send and keeps the gateway
+        queue shallow. A round that sent nothing (a silent-bot re-request) waits
+        just the report window.
         """
+        if chunks_sent <= 0:
+            return self.settings.report_timeout
+        residual = chunks_sent * max(
+            0.0,
+            self.settings.per_chunk_delivery - self.settings.inter_chunk_delay,
+        )
         return min(
-            self.settings.report_timeout
-            + chunks_sent * self.settings.per_chunk_delivery,
-            self.settings.wait_cap,
+            self.settings.report_timeout + residual, self.settings.wait_cap
         )
 
     # ------------------------------------------------------------------ #

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -190,7 +190,9 @@ class BlockTransfer:
         # Straggler set (reversible: a bot rejoins when it reports again).
         self._straggler: set[str] = set()
         # Blocks each device never fully confirmed (for the unicast pass).
-        self._incomplete: dict[str, set[int]] = {addr: set() for addr in self.devices}
+        self._incomplete: dict[str, set[int]] = {
+            addr: set() for addr in self.devices
+        }
 
         # Transient per-block counters, reset in _reset_block_state.
         self._silent: dict[str, int] = {}
@@ -253,7 +255,9 @@ class BlockTransfer:
     # ------------------------------------------------------------------ #
     # RX-thread entry points (thread-safe).
     # ------------------------------------------------------------------ #
-    def on_report(self, addr: str, block_index: int, received_mask: int) -> None:
+    def on_report(
+        self, addr: str, block_index: int, received_mask: int
+    ) -> None:
         """Feed a BLOCK_REPORT_RESP into the current round (RX thread)."""
         with self._lock:
             self._round_reports[addr] = (block_index, received_mask)
@@ -450,9 +454,9 @@ class BlockTransfer:
                 if not blocks:
                     break
                 for block in blocks:
-                    missing = self.full_block_mask(block) & ~self.confirmed_mask(
-                        addr, block
-                    )
+                    missing = self.full_block_mask(
+                        block
+                    ) & ~self.confirmed_mask(addr, block)
                     with self._lock:
                         self._round_reports = {}
                     self._send_chunks(
@@ -476,7 +480,9 @@ class BlockTransfer:
         reported_block, mask = rep
         if reported_block == block:
             self._straggler.discard(addr)
-            self._apply_confirmed(addr, block, mask & self.full_block_mask(block))
+            self._apply_confirmed(
+                addr, block, mask & self.full_block_mask(block)
+            )
 
     def _finalize(self) -> None:
         """Ask each device to verify the whole image against its SHA256."""

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -18,6 +18,10 @@ tested with a fake transport and zero real time: ``send_payload``, ``clock`` and
 ``sleep`` are all parameters. ``on_report`` / ``on_finalize_resp`` are fed from
 the controller's RX thread (or a test), guarded by a lock.
 
+Nothing here knows what radio it is running on. How fast chunks may be
+injected and how long a report window needs to be are properties of the link,
+so they arrive as a :class:`BlockOTASettings` derived by the adapter.
+
 Reference: BLE Mesh DFU BLOB Transfer (Push mode) for the block/bitmap shape,
 RFC 9177 (CoAP Q-Block) for burst pacing and exponential backoff. Design and
 rationale live in ``plans/swarmit-fast-ota/plan.html``.
@@ -98,91 +102,6 @@ class BlockOTASettings:
     straggler_max_rounds: int = STRAGGLER_MAX_ROUNDS_DEFAULT
     finalize_max_rounds: int = FINALIZE_MAX_ROUNDS_DEFAULT
     max_rounds_per_block: int = MAX_ROUNDS_PER_BLOCK_DEFAULT
-
-
-@dataclass(frozen=True)
-class MariSchedule:
-    """Geometry of a Mari schedule - the source of truth for OTA pacing.
-
-    A gateway transmits one downlink frame per D-cell per slotframe, and each
-    joined node gets one uplink cell per slotframe (so all nodes can report
-    within a single slotframe). These two facts drive the whole pacing model.
-    Cell counts from mari/firmware/mari/all_schedules.c.
-    """
-
-    name: str
-    n_slots: int
-    d_cells: int
-    u_cells: int
-    max_nodes: int
-    slot_s: float = 0.00178  # MARI_WHOLE_SLOT_DURATION (~1.78 ms)
-
-    @property
-    def slotframe_s(self) -> float:
-        return self.n_slots * self.slot_s
-
-    @property
-    def downlink_pps(self) -> float:
-        """Gateway downlink capacity in frames/s (all D-cells packed)."""
-        return self.d_cells / self.slotframe_s
-
-
-MARI_SCHEDULES: dict[str, "MariSchedule"] = {
-    "tiny": MariSchedule("tiny", 17, 2, 10, 10),
-    "medium": MariSchedule("medium", 67, 10, 44, 44),
-    "big": MariSchedule("big", 101, 16, 66, 66),
-    "huge": MariSchedule("huge", 149, 22, 102, 102),
-}
-
-# Share of the gateway's downlink slots OTA drives. This is the binding term now
-# that the device keeps up (see DEVICE_CHUNK_RATE_HZ). 0.75 leaves ~25% of the
-# D-slots for beacons/join/commands and headroom against the shared TX queue,
-# while pushing OTA at most of the radio's downlink capacity.
-OTA_DOWNLINK_UTILIZATION = 0.75
-
-# Device chunk-write ceiling. Once the firmware stopped acking every chunk (the
-# per-chunk uplink ack was throttling the transfer to the node's one uplink cell
-# per slotframe) and the shared chunk buffer read was guarded, the device
-# handles the full radio rate cleanly on hardware - a 12 ms/chunk (~84/s) inject
-# flashes the 464-chunk image in ~24 s (was ~137 s), finalize OK. So this is now
-# the radio rate, not the old ~6.7 single-buffer clamp; the schedule geometry
-# above (downlink_pps x utilization) is what actually binds.
-DEVICE_CHUNK_RATE_HZ = 84.0
-
-
-def settings_for_fleet(
-    schedule: str = "medium",
-    n_bots: int = 1,
-    utilization: float = OTA_DOWNLINK_UTILIZATION,
-    device_chunk_rate: float = DEVICE_CHUNK_RATE_HZ,
-) -> "BlockOTASettings":
-    """Derive block-OTA pacing from the Mari schedule, the device, and fleet size.
-
-    - inject rate = min(radio downlink x utilization, device chunk-write rate).
-      We broadcast, so one frame reaches every bot - the radio term is
-      independent of fleet size. The device term binds today.
-    - report window = a couple of slotframes (every bot reports within one),
-      growing gently as the fleet fills the uplink.
-
-    ``per_chunk_delivery`` is the conservative, HIL-validated churn-free delivery
-    estimate; it (and the report model generally) is deliberately not aggressive
-    and will be re-derived once the firmware ring raises the device rate.
-    """
-    sched = MARI_SCHEDULES.get(schedule, MARI_SCHEDULES["medium"])
-    inject_pps = max(1.0, min(sched.downlink_pps * utilization, device_chunk_rate))
-    inter_chunk = 1.0 / inject_pps
-    report_slotframes = 2.0 + max(0, n_bots - 1) / max(1, sched.u_cells)
-    return BlockOTASettings(
-        block_size=BLOCK_SIZE_DEFAULT,
-        inter_chunk_delay=inter_chunk,
-        # We pace injection at the delivery rate, so a block drains as it is sent
-        # and the report wait only needs the collection window - no big residual.
-        # (With the pre-firmware per-chunk-ack path the device could not keep up
-        # and this needed a long drain margin; the ring/no-ack fix removes that.)
-        per_chunk_delivery=inter_chunk,
-        report_timeout=sched.slotframe_s * report_slotframes,
-        wait_cap=WAIT_CAP_DEFAULT,
-    )
 
 
 class ChunkLike(Protocol):

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -120,7 +120,13 @@ class DeviceResult:
 
     @property
     def success(self) -> bool:
-        return self.finalized and self.confirmed_chunks == self.total_chunks
+        # The whole-image finalize SHA256 is authoritative: if the device says
+        # it matches, every byte is correctly in flash - regardless of what the
+        # delivery bitmap tracked. Under heavy loss/retransmit the bitmap can
+        # under-count (a report is lost, or the device's per-block mask is
+        # overwritten as it advances) while the image is in fact complete;
+        # gating success on confirmed==total then fails a perfectly good flash.
+        return self.finalized
 
 
 class BlockTransfer:

--- a/swarmit/testbed/ota.py
+++ b/swarmit/testbed/ota.py
@@ -134,9 +134,11 @@ MARI_SCHEDULES: dict[str, "MariSchedule"] = {
     "huge": MariSchedule("huge", 149, 22, 102, 102),
 }
 
-# Share of the gateway's downlink slots OTA may drive once it is fast enough to
-# be radio-bound. NOT the binding constraint today - see DEVICE_CHUNK_RATE_HZ.
-OTA_DOWNLINK_UTILIZATION = 0.5
+# Share of the gateway's downlink slots OTA drives. This is the binding term now
+# that the device keeps up (see DEVICE_CHUNK_RATE_HZ). 0.75 leaves ~25% of the
+# D-slots for beacons/join/commands and headroom against the shared TX queue,
+# while pushing OTA at most of the radio's downlink capacity.
+OTA_DOWNLINK_UTILIZATION = 0.75
 
 # Device chunk-write ceiling. Once the firmware stopped acking every chunk (the
 # per-chunk uplink ack was throttling the transfer to the node's one uplink cell

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -498,9 +498,7 @@ register_parser(
     PayloadType.SWARMIT_OTA_BLOCK_REPORT_RESP, PayloadOTABlockReportResp
 )
 register_parser(PayloadType.SWARMIT_OTA_FINALIZE, PayloadOTAFinalize)
-register_parser(
-    PayloadType.SWARMIT_OTA_FINALIZE_RESP, PayloadOTAFinalizeResp
-)
+register_parser(PayloadType.SWARMIT_OTA_FINALIZE_RESP, PayloadOTAFinalizeResp)
 register_parser(PayloadType.SWARMIT_EVENT_LOG, PayloadEvent)
 register_parser(PayloadType.SWARMIT_MESSAGE, PayloadMessage)
 register_parser(PayloadType.SWARMIT_LH2_CALIBRATION, PayloadCalibrationData)

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -66,10 +66,14 @@ class PayloadType(IntEnum):
     METRICS_PROBE = MariDefaultPayloadType.METRICS_PROBE
 
 
-# OTA protocol version reported by a bootloader in its OTA_START_ACK. Version 1
-# is the legacy per-chunk stop-and-wait path (no version byte on the wire, so it
-# parses as 1); version 2 is the block/bitmap-NACK path. The controller uses the
-# block path only with the subset of bots that report version >= 2.
+# Destination that reaches every node on the network.
+BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
+
+
+# OTA protocol version a bootloader reports in its OTA_START_ACK. Version 1 is
+# the retired per-chunk stop-and-wait path: it sent no version byte, so an ack
+# from such a bootloader parses as 1. Version 2 is the block/bitmap path. A bot
+# that does not report 2 cannot be flashed over the air any more.
 OTA_PROTOCOL_VERSION_LEGACY = 1
 OTA_PROTOCOL_VERSION_BLOCK = 2
 
@@ -376,7 +380,12 @@ class PayloadOTAChunkAck(Payload):
 
 @dataclass
 class PayloadOTABlockReportReq(Payload):
-    """Host -> device: request a bot's received-chunk bitmap for one block."""
+    """Host -> device: request a bot's received-chunk bitmap for one block.
+
+    The device answers with the block it currently holds, not necessarily the
+    one asked about - the fields say which block prompted the request and how
+    wide it is, and a device on an older block is read as needing all of it.
+    """
 
     metadata: list[PayloadFieldMetadata] = dataclasses.field(
         default_factory=lambda: [

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -47,6 +47,12 @@ class PayloadType(IntEnum):
     SWARMIT_OTA_CHUNK_ACK = 0x87
     SWARMIT_EVENT_GPIO = 0x88
     SWARMIT_EVENT_LOG = 0x89
+    # Block-OTA (fast OTA) additions. Host -> device: report request and
+    # finalize; device -> host: report response and finalize response.
+    SWARMIT_OTA_BLOCK_REPORT_REQ = 0x8A
+    SWARMIT_OTA_BLOCK_REPORT_RESP = 0x8B
+    SWARMIT_OTA_FINALIZE = 0x8C
+    SWARMIT_OTA_FINALIZE_RESP = 0x8D
 
     # Custom messages
     SWARMIT_MESSAGE = 0xA0
@@ -58,6 +64,14 @@ class PayloadType(IntEnum):
 
     # Marilib metrics probe
     METRICS_PROBE = MariDefaultPayloadType.METRICS_PROBE
+
+
+# OTA protocol version reported by a bootloader in its OTA_START_ACK. Version 1
+# is the legacy per-chunk stop-and-wait path (no version byte on the wire, so it
+# parses as 1); version 2 is the block/bitmap-NACK path. The controller uses the
+# block path only with the subset of bots that report version >= 2.
+OTA_PROTOCOL_VERSION_LEGACY = 1
+OTA_PROTOCOL_VERSION_BLOCK = 2
 
 
 # First byte of a raw LH2 capture sample carried inside a SWARMIT_EVENT_LOG
@@ -255,7 +269,11 @@ class PayloadReset(Payload):
 
 @dataclass
 class PayloadOTAStart(Payload):
-    """Dataclass that holds an OTA start packet."""
+    """Dataclass that holds an OTA start packet.
+
+    `version` is appended at the end so a legacy bootloader that parses only
+    the first 8 bytes (image size + chunk count) tolerates the extra byte.
+    """
 
     metadata: list[PayloadFieldMetadata] = dataclasses.field(
         default_factory=lambda: [
@@ -263,11 +281,13 @@ class PayloadOTAStart(Payload):
             PayloadFieldMetadata(
                 name="fw_chunk_counts", disp="chunks", length=4
             ),
+            PayloadFieldMetadata(name="version", disp="ver.", length=1),
         ]
     )
 
     fw_length: int = 0
     fw_chunk_count: int = 0
+    version: int = OTA_PROTOCOL_VERSION_BLOCK
 
 
 @dataclass
@@ -318,11 +338,27 @@ class PayloadCalibrationData(Payload):
 
 @dataclass
 class PayloadOTAStartAck(Payload):
-    """Dataclass that holds an application OTA start ACK notification packet."""
+    """Dataclass that holds an application OTA start ACK notification packet.
+
+    A block-OTA bootloader appends its `version` byte; a legacy bootloader
+    sends the empty ack, which parses as version 1.
+    """
 
     metadata: list[PayloadFieldMetadata] = dataclasses.field(
-        default_factory=lambda: []
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="version", disp="ver.", length=1),
+        ]
     )
+
+    version: int = OTA_PROTOCOL_VERSION_LEGACY
+
+    def from_bytes(self, bytes_):
+        # Legacy bootloaders send an empty ack (no version byte); treat that
+        # as version 1 so mixed fleets negotiate correctly.
+        if len(bytes_) == 0:
+            self.version = OTA_PROTOCOL_VERSION_LEGACY
+            return self
+        return super().from_bytes(bytes_)
 
 
 @dataclass
@@ -336,6 +372,69 @@ class PayloadOTAChunkAck(Payload):
     )
 
     index: int = 0
+
+
+@dataclass
+class PayloadOTABlockReportReq(Payload):
+    """Host -> device: request a bot's received-chunk bitmap for one block."""
+
+    metadata: list[PayloadFieldMetadata] = dataclasses.field(
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="block_index", disp="blk", length=4),
+            PayloadFieldMetadata(name="block_size", disp="w"),
+        ]
+    )
+
+    block_index: int = 0
+    block_size: int = 0
+
+
+@dataclass
+class PayloadOTABlockReportResp(Payload):
+    """Device -> host: bitmap of received+verified chunks for its block.
+
+    `block_index` is the block the bot currently holds; a bot that has not yet
+    written any chunk of the requested block reports an earlier block, which the
+    controller reads as "needs the whole requested block".
+    """
+
+    metadata: list[PayloadFieldMetadata] = dataclasses.field(
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="block_index", disp="blk", length=4),
+            PayloadFieldMetadata(name="received_mask", disp="mask", length=4),
+            PayloadFieldMetadata(name="status", disp="st."),
+        ]
+    )
+
+    block_index: int = 0
+    received_mask: int = 0
+    status: int = 0
+
+
+@dataclass
+class PayloadOTAFinalize(Payload):
+    """Host -> device: verify the whole written image against this SHA256."""
+
+    metadata: list[PayloadFieldMetadata] = dataclasses.field(
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="sha", type_=bytes, length=32),
+        ]
+    )
+
+    sha: bytes = dataclasses.field(default_factory=lambda: bytearray)
+
+
+@dataclass
+class PayloadOTAFinalizeResp(Payload):
+    """Device -> host: 1 if the image SHA256 matched, 0 otherwise."""
+
+    metadata: list[PayloadFieldMetadata] = dataclasses.field(
+        default_factory=lambda: [
+            PayloadFieldMetadata(name="ok", disp="ok"),
+        ]
+    )
+
+    ok: int = 0
 
 
 @dataclass
@@ -383,6 +482,16 @@ register_parser(PayloadType.SWARMIT_OTA_START, PayloadOTAStart)
 register_parser(PayloadType.SWARMIT_OTA_CHUNK, PayloadOTAChunk)
 register_parser(PayloadType.SWARMIT_OTA_START_ACK, PayloadOTAStartAck)
 register_parser(PayloadType.SWARMIT_OTA_CHUNK_ACK, PayloadOTAChunkAck)
+register_parser(
+    PayloadType.SWARMIT_OTA_BLOCK_REPORT_REQ, PayloadOTABlockReportReq
+)
+register_parser(
+    PayloadType.SWARMIT_OTA_BLOCK_REPORT_RESP, PayloadOTABlockReportResp
+)
+register_parser(PayloadType.SWARMIT_OTA_FINALIZE, PayloadOTAFinalize)
+register_parser(
+    PayloadType.SWARMIT_OTA_FINALIZE_RESP, PayloadOTAFinalizeResp
+)
 register_parser(PayloadType.SWARMIT_EVENT_LOG, PayloadEvent)
 register_parser(PayloadType.SWARMIT_MESSAGE, PayloadMessage)
 register_parser(PayloadType.SWARMIT_LH2_CALIBRATION, PayloadCalibrationData)

--- a/swarmit/testbed/webserver.py
+++ b/swarmit/testbed/webserver.py
@@ -311,7 +311,8 @@ async def flash_stream(payload: FlashRequest, request: Request):
     """OTA flash with progress streamed back as Server-Sent Events.
 
     Event types yielded in order:
-      - "flash_started":     {image_size, total_chunks, fw_hash, devices}
+      - "flash_started":     {image_size, total_chunks, fw_hash, devices,
+                              block_size, n_blocks}
       - "chunk" (repeated):  {addr, acked, total}   — cumulative acked count
       - "device_done" (per): {addr, success, retries}
       - "complete":          {all_success, elapsed_s}
@@ -370,13 +371,31 @@ async def flash_stream(payload: FlashRequest, request: Request):
             )
             return
 
+        stale = controller.stale_bootloaders(start_data["acked"])
+        if stale:
+            yield _sse(
+                {
+                    "type": "error",
+                    "message": (
+                        f"{len(stale)} device(s) run a bootloader older than "
+                        f"the block OTA protocol: {stale}. Re-provision them "
+                        "with 'dotbot device flash-swarmit-sandbox'."
+                    ),
+                }
+            )
+            return
+
+        block_size = controller.ota_block_size
+        total_chunks = len(controller.chunks)
         yield _sse(
             {
                 "type": "flash_started",
                 "image_size": len(fw),
-                "total_chunks": len(controller.chunks),
+                "total_chunks": total_chunks,
                 "fw_hash": start_data["ota"].fw_hash.hex().upper(),
                 "devices": sorted(start_data["acked"]),
+                "block_size": block_size,
+                "n_blocks": (total_chunks + block_size - 1) // block_size,
             }
         )
 

--- a/swarmit/tests/test_adapter.py
+++ b/swarmit/tests/test_adapter.py
@@ -1,13 +1,26 @@
 from unittest.mock import patch
 
+import pytest
 from dotbot_utils.protocol import Packet
 from marilib.mari_protocol import Frame as MariFrame
 from marilib.mari_protocol import Header as MariHeader
 from marilib.mari_protocol import NextProto
-from marilib.model import EdgeEvent
+from marilib.model import SCHEDULES, EdgeEvent, GatewayInfo, MariGateway
 
-from swarmit.testbed.adapter import MarilibCloudAdapter, MarilibEdgeAdapter
+from swarmit.testbed.adapter import (
+    OTA_DOWNLINK_UTILIZATION,
+    LinkGeometry,
+    MarilibCloudAdapter,
+    MarilibEdgeAdapter,
+    derive_block_settings,
+)
 from swarmit.testbed.protocol import PayloadStatus
+
+# Mari schedule ids, as announced by a gateway (marilib.model.SCHEDULES).
+SCHEDULE_HUGE = 1
+SCHEDULE_BIG = 3
+SCHEDULE_MEDIUM = 4
+SCHEDULE_TINY = 6
 
 
 @patch("swarmit.testbed.adapter.MarilibSerialAdapter")
@@ -155,6 +168,90 @@ def test_marilib_cloud_adapter(send_frame_mock, _, capsys):
         next_proto=NextProto.SWARMIT_TESTBED,
     )
     adapter.close()
+
+
+def test_link_geometry_from_schedule_id():
+    geometry = LinkGeometry.from_schedule_id(SCHEDULE_MEDIUM)
+    schedule = SCHEDULES[SCHEDULE_MEDIUM]
+    assert geometry.schedule_name == "medium"
+    assert geometry.slotframe_s == pytest.approx(
+        schedule["sf_duration"] / 1000.0
+    )
+    # One downlink frame per D-cell per slotframe.
+    assert geometry.downlink_pps == pytest.approx(
+        schedule["d_down"] / geometry.slotframe_s
+    )
+    assert geometry.reported is True
+    # An id the gateway has not reported yet (0 is the GatewayInfo default).
+    assert LinkGeometry.from_schedule_id(0) is None
+
+
+def test_link_geometry_fallback_is_flagged():
+    fallback = LinkGeometry.fallback()
+    assert fallback.schedule_name == "medium"
+    assert fallback.reported is False
+
+
+def test_derive_block_settings_paces_to_the_downlink():
+    geometry = LinkGeometry.from_schedule_id(SCHEDULE_MEDIUM)
+    settings = derive_block_settings(geometry, n_bots=1)
+    assert settings.inter_chunk_delay == pytest.approx(
+        1.0 / (geometry.downlink_pps * OTA_DOWNLINK_UTILIZATION), rel=0.02
+    )
+    assert settings.block_size == 32
+    # The report window grows with the fleet...
+    assert (
+        derive_block_settings(geometry, n_bots=100).report_timeout
+        > settings.report_timeout
+    )
+    # ...and a denser schedule (shorter slotframe) shortens it.
+    tiny = LinkGeometry.from_schedule_id(SCHEDULE_TINY)
+    assert (
+        derive_block_settings(tiny, n_bots=1).report_timeout
+        < settings.report_timeout
+    )
+
+
+def test_derive_block_settings_clamps_to_the_device():
+    geometry = LinkGeometry.from_schedule_id(SCHEDULE_HUGE)
+    # A device slower than the radio binds the inject rate instead.
+    settings = derive_block_settings(
+        geometry, n_bots=1, utilization=1.0, device_chunk_rate=5.0
+    )
+    assert settings.inter_chunk_delay == pytest.approx(1.0 / 5.0, rel=0.01)
+
+
+def test_derive_block_settings_without_a_reported_schedule():
+    # No geometry: pace with the fallback rather than refusing to flash.
+    assert (
+        derive_block_settings(None, n_bots=1).inter_chunk_delay
+        == derive_block_settings(
+            LinkGeometry.fallback(), n_bots=1
+        ).inter_chunk_delay
+    )
+
+
+@patch("swarmit.testbed.adapter.MarilibSerialAdapter")
+def test_edge_adapter_reports_link_geometry(_):
+    adapter = MarilibEdgeAdapter(
+        port="p", baudrate=1, busy_wait_timeout=0.1
+    )
+    # Nothing reported yet.
+    assert adapter.link_geometry() is None
+    adapter.mari.gateway.info.schedule_id = SCHEDULE_HUGE
+    assert adapter.link_geometry().schedule_name == "huge"
+
+
+@patch("swarmit.testbed.adapter.MarilibMQTTAdapter")
+def test_cloud_adapter_reports_link_geometry(_):
+    adapter = MarilibCloudAdapter(
+        host="h", port=1, use_tls=False, network_id=2, busy_wait_timeout=0.1
+    )
+    assert adapter.link_geometry() is None
+    adapter.mari.gateways = {
+        0: MariGateway(info=GatewayInfo(address=0, schedule_id=SCHEDULE_BIG))
+    }
+    assert adapter.link_geometry().schedule_name == "big"
 
 
 @patch("swarmit.testbed.adapter.MarilibMQTTAdapter")

--- a/swarmit/tests/test_adapter.py
+++ b/swarmit/tests/test_adapter.py
@@ -233,9 +233,7 @@ def test_derive_block_settings_without_a_reported_schedule():
 
 @patch("swarmit.testbed.adapter.MarilibSerialAdapter")
 def test_edge_adapter_reports_link_geometry(_):
-    adapter = MarilibEdgeAdapter(
-        port="p", baudrate=1, busy_wait_timeout=0.1
-    )
+    adapter = MarilibEdgeAdapter(port="p", baudrate=1, busy_wait_timeout=0.1)
     # Nothing reported yet.
     assert adapter.link_geometry() is None
     adapter.mari.gateway.info.schedule_id = SCHEDULE_HUGE

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -10,15 +10,31 @@ from swarmit.testbed.controller import (
     Controller,
     ControllerSettings,
     ResetLocation,
+    StaleBootloaderError,
 )
 from swarmit.testbed.logger import setup_logging
-from swarmit.testbed.protocol import StatusType
+from swarmit.testbed.ota import BlockOTASettings
+from swarmit.testbed.protocol import OTA_PROTOCOL_VERSION_LEGACY, StatusType
 from swarmit.tests.utils import (
-    ChunkAckStrategy,
+    ChunkLossStrategy,
     MarilibMQTTAdapterMock,
     MarilibSerialAdapterMock,
     SwarmitNode,
 )
+
+
+def _fast_ota_settings(*args, **kwargs) -> BlockOTASettings:
+    """Pacing stand-in for tests: no inter-chunk delay, short report window.
+
+    The real derivation paces sends at the radio's downlink rate, which would
+    stretch these transfers to tens of seconds. The mocked transport delivers
+    instantly, so here pacing only costs wall clock.
+    """
+    return BlockOTASettings(
+        inter_chunk_delay=0.0,
+        per_chunk_delivery=0.0,
+        report_timeout=0.02,
+    )
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
@@ -556,6 +572,7 @@ def test_controller_send_lh2_calibration_raw_format_rejected():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -585,10 +602,11 @@ def test_controller_ota_broadcast():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
-def test_controller_ota_broadcast_verbose(capsys):
+def test_controller_ota_broadcast_verbose():
     controller = Controller(
         ControllerSettings(adapter_wait_timeout=0.1, verbose=True)
     )
@@ -612,11 +630,11 @@ def test_controller_ota_broadcast_verbose(capsys):
     result = controller.transfer(firmware, ota_data["acked"])
     time.sleep(0.3)
     assert all([transfer.success for transfer in result.values()]) is True
-    assert "Transfer completed" in capsys.readouterr().out
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -644,29 +662,30 @@ def test_controller_ota_unicast():
     result = controller.transfer(firmware, ota_data["acked"])
     time.sleep(0.3)
     assert all([transfer.success for transfer in result.values()]) is True
+    # The untargeted bot was never written to.
+    assert nodes[1].received_chunks == set()
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
-def test_controller_ota_with_retries(capsys):
-    controller = Controller(
-        ControllerSettings(
-            adapter_wait_timeout=0.1, ota_max_retries=3, verbose=True
-        )
-    )
+def test_controller_ota_repairs_lost_chunks():
+    """A chunk lost on the downlink is repaired from the block report."""
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     test_adapter = controller.interface.mari.serial_interface
+    # node1 misses chunk 5 twice, then accepts the repair broadcast.
     node1 = SwarmitNode(
         address=0x01,
-        ack_strategy=ChunkAckStrategy(ack_miss_index=5, ack_miss_retries=2),
+        loss_strategy=ChunkLossStrategy(drop_index=5, drop_count=2),
         adapter=test_adapter,
     )
+    # node2 never receives chunk 5, so its image stays incomplete.
     node2 = SwarmitNode(
         address=0x02,
-        ack_strategy=ChunkAckStrategy(ack_miss_index=5, ack_miss_retries=4),
-        ota_should_fail=True,
+        loss_strategy=ChunkLossStrategy(drop_index=5, drop_count=10_000),
         adapter=test_adapter,
     )
     nodes = [node1, node2]
@@ -677,36 +696,52 @@ def test_controller_ota_with_retries(capsys):
 
     ota_data = controller.start_ota(firmware)
     assert ota_data["acked"] == [f"{node.address:08X}" for node in nodes]
-    assert ota_data["missed"] == []
-
-    for node in nodes:
-        assert node.status == StatusType.Programming
 
     result = controller.transfer(firmware, ota_data["acked"])
-    assert "Transfer completed with" in capsys.readouterr().out
     assert result["00000001"].success is True
     assert result["00000002"].success is False
-    # retries are equal for both nodes (broadcast)
-    assert sum(chunk.retries for chunk in result["00000001"].chunks) == 3
-    assert sum(chunk.retries for chunk in result["00000002"].chunks) == 3
+    # The repair actually delivered the chunk rather than giving up on it.
+    assert 5 in node1.received_chunks
+    assert 5 not in node2.received_chunks
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
-def test_controller_ota_index_out_range(capsys):
-    controller = Controller(
-        ControllerSettings(
-            adapter_wait_timeout=0.1, ota_max_retries=3, verbose=True
-        )
+def test_controller_ota_finalize_mismatch_fails():
+    """A complete delivery whose image SHA does not match is not a success."""
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
+    test_adapter = controller.interface.mari.serial_interface
+    node = SwarmitNode(
+        address=0x01, ota_should_fail=True, adapter=test_adapter
     )
+    test_adapter.add_node(node)
+
+    firmware = b"\x00" * 2**16
+
+    ota_data = controller.start_ota(firmware)
+    result = controller.transfer(firmware, ota_data["acked"])
+    # Every chunk arrived, but the device rejected the whole-image hash.
+    assert len(node.received_chunks) == node.total_chunks
+    assert result["00000001"].success is False
+
+
+@patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
+@patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
+@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch(
+    "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
+)
+def test_controller_ota_refuses_stale_bootloader():
+    """A bot that never announces the block protocol aborts the flash."""
+    controller = Controller(ControllerSettings(adapter_wait_timeout=0.1))
     test_adapter = controller.interface.mari.serial_interface
     node = SwarmitNode(
         address=0x01,
-        ack_strategy=ChunkAckStrategy(ack_out_of_range_index=50),
-        ota_should_fail=True,
+        ota_protocol_version=OTA_PROTOCOL_VERSION_LEGACY,
         adapter=test_adapter,
     )
     test_adapter.add_node(node)
@@ -714,14 +749,15 @@ def test_controller_ota_index_out_range(capsys):
     firmware = b"\x00" * 2**16
 
     ota_data = controller.start_ota(firmware)
-    assert ota_data["acked"] == [f"{node.address:08X}"]
-    assert ota_data["missed"] == []
-    assert node.status == StatusType.Programming
+    assert ota_data["acked"] == ["00000001"]
+    assert controller.stale_bootloaders(ota_data["acked"]) == ["00000001"]
 
-    result = controller.transfer(firmware, ota_data["acked"])
-    assert "Transfer completed with" in capsys.readouterr().out
-    assert result["00000001"].success is False
-    assert sum(chunk.retries for chunk in result["00000001"].chunks) == 3
+    with pytest.raises(StaleBootloaderError) as exc:
+        controller.transfer(firmware, ota_data["acked"])
+    assert "00000001" in str(exc.value)
+    assert "flash-swarmit-sandbox" in str(exc.value)
+    # Aborted before any chunk went on the wire.
+    assert node.received_chunks == set()
 
 
 def test_controller_chunk_repr():

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -572,7 +572,7 @@ def test_controller_send_lh2_calibration_raw_format_rejected():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -602,7 +602,7 @@ def test_controller_ota_broadcast():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -634,7 +634,7 @@ def test_controller_ota_broadcast_verbose():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -668,7 +668,7 @@ def test_controller_ota_unicast():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -707,7 +707,7 @@ def test_controller_ota_repairs_lost_chunks():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )
@@ -731,7 +731,7 @@ def test_controller_ota_finalize_mismatch_fails():
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)
 @patch("swarmit.testbed.controller.OTA_ACK_TIMEOUT_DEFAULT", 0.1)
-@patch("swarmit.testbed.controller.settings_for_fleet", _fast_ota_settings)
+@patch("swarmit.testbed.controller.derive_block_settings", _fast_ota_settings)
 @patch(
     "swarmit.testbed.adapter.MarilibSerialAdapter", MarilibSerialAdapterMock
 )

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -30,11 +30,7 @@ def _fast_ota_settings(*args, **kwargs) -> BlockOTASettings:
     stretch these transfers to tens of seconds. The mocked transport delivers
     instantly, so here pacing only costs wall clock.
     """
-    return BlockOTASettings(
-        inter_chunk_delay=0.0,
-        per_chunk_delivery=0.0,
-        report_timeout=0.02,
-    )
+    return BlockOTASettings(inter_chunk_delay=0.0, report_timeout=0.02)
 
 
 @patch("swarmit.testbed.controller.COMMAND_TIMEOUT", 0.1)

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -34,7 +34,9 @@ class SimpleChunk:
     data: bytes
 
 
-def make_chunks(image: bytes, chunk_size: int = CHUNK_SIZE) -> list[SimpleChunk]:
+def make_chunks(
+    image: bytes, chunk_size: int = CHUNK_SIZE
+) -> list[SimpleChunk]:
     chunks = []
     for i in range(0, len(image), chunk_size):
         data = image[i : i + chunk_size]
@@ -101,9 +103,7 @@ class FakeTransport:
     def _targets(self, dest):
         if dest == BROADCAST_ADDRESS:
             return list(self.devices.items())
-        return [
-            (a, d) for a, d in self.devices.items() if int(a, 16) == dest
-        ]
+        return [(a, d) for a, d in self.devices.items() if int(a, 16) == dest]
 
     def send_payload(self, dest, payload):
         if isinstance(payload, PayloadOTAChunk):

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -96,6 +96,7 @@ class FakeTransport:
         self.report_loss = report_loss or (lambda addr, block: False)
         self.bt: BlockTransfer | None = None
         self.chunk_sends = 0
+        self.finalize_dests: list[int] = []
 
     def _targets(self, dest):
         if dest == BROADCAST_ADDRESS:
@@ -116,6 +117,7 @@ class FakeTransport:
                     block, mask = dev.report()
                     self.bt.on_report(addr, block, mask)
         elif isinstance(payload, PayloadOTAFinalize):
+            self.finalize_dests.append(dest)
             for addr, dev in self._targets(dest):
                 if self.report_loss(addr, -1):
                     continue
@@ -124,13 +126,21 @@ class FakeTransport:
                 )
 
 
-def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
+def build(
+    devices,
+    image,
+    settings=None,
+    chunk_loss=None,
+    report_loss=None,
+    broadcast=True,
+    all_devices=None,
+):
     chunks = make_chunks(image)
     settings = settings or BlockOTASettings(
         block_size=4, inter_chunk_delay=0.0
     )
     transport = FakeTransport(
-        devices,
+        all_devices or devices,
         settings.block_size,
         len(chunks),
         chunk_loss=chunk_loss,
@@ -143,6 +153,7 @@ def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
         send_payload=transport.send_payload,
         image_sha=hashlib.sha256(image).digest(),
         settings=settings,
+        broadcast=broadcast,
         sleep=lambda *_: None,
         on_progress=lambda a, i: progress.append((a, i)),
     )
@@ -162,32 +173,6 @@ def test_block_layout_and_masks():
     assert bt.full_block_mask(0) == 0b1111
     assert bt.full_block_mask(2) == 0b111  # only 3 chunks
     assert bt.indices_from_mask(1, 0b1010) == [5, 7]
-
-
-def test_report_wait_waits_for_residual_backlog():
-    # No pacing: wait covers the full drain of what was sent.
-    unpaced = BlockOTASettings(
-        block_size=4,
-        report_timeout=0.3,
-        per_chunk_delivery=0.25,
-        inter_chunk_delay=0.0,
-        wait_cap=12.0,
-    )
-    bt, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=unpaced)
-    assert bt.report_wait(0) == pytest.approx(0.3)  # nothing sent
-    assert bt.report_wait(4) == pytest.approx(0.3 + 4 * 0.25)  # full drain
-    assert bt.report_wait(1000) == pytest.approx(12.0)  # capped
-
-    # Fully paced (delay >= drain): the send already drained it, so we wait
-    # only the report window regardless of how many chunks were sent.
-    paced = BlockOTASettings(
-        block_size=4,
-        report_timeout=0.3,
-        per_chunk_delivery=0.25,
-        inter_chunk_delay=0.25,
-    )
-    bt2, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=paced)
-    assert bt2.report_wait(32) == pytest.approx(0.3)
 
 
 def test_repair_mask_unions_reporting_devices():
@@ -213,7 +198,7 @@ def test_silent_device_contributes_no_repair():
 def test_earlier_reported_block_means_needs_full_block():
     image = make_image(8 * CHUNK_SIZE)  # 2 blocks of 4
     bt, transport, _, _ = build(["AAAA"], image)
-    bt._reset_block_state(1)
+    bt._reset_block_state()
     # Device reports it is still on block 0 while we evaluate block 1.
     bt._round_reports = {"AAAA": (0, 0b1111)}
     bt._evaluate_round(1)
@@ -377,3 +362,32 @@ def test_unicast_straggler_recovery_succeeds():
     results = bt.run()
     assert results["AAAA"].success
     assert not results["AAAA"].straggler
+
+
+def test_finalize_broadcasts_when_every_device_is_pending():
+    image = make_image(8 * CHUNK_SIZE)
+    bt, transport, _, _ = build(["AAAA", "BBBB"], image)
+    results = bt.run()
+    assert all(r.success for r in results.values())
+    # One frame reaches both bots, so no per-device finalize is needed.
+    assert transport.finalize_dests == [BROADCAST_ADDRESS]
+
+
+def test_finalize_is_unicast_for_a_targeted_transfer():
+    """A targeted transfer must not ask the whole network to verify.
+
+    Broadcasting FINALIZE would make untargeted bots hash their own unrelated
+    flash and answer about it.
+    """
+    image = make_image(8 * CHUNK_SIZE)
+    bt, transport, _, _ = build(
+        ["AAAA"],
+        image,
+        broadcast=False,
+        all_devices=["AAAA", "BBBB"],
+    )
+    results = bt.run()
+    assert results["AAAA"].success
+    assert transport.finalize_dests == [int("AAAA", 16)]
+    # The bot that was not targeted was never written to or asked anything.
+    assert transport.devices["BBBB"].received == set()

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -13,6 +13,7 @@ import pytest
 from swarmit.testbed.ota import (
     BROADCAST_ADDRESS,
     MARI_SCHEDULES,
+    OTA_DOWNLINK_UTILIZATION,
     BlockOTASettings,
     BlockTransfer,
     settings_for_fleet,
@@ -160,7 +161,9 @@ def test_settings_for_fleet_derives_from_schedule():
     # ~24 ms/chunk on medium at util 0.5, block 32.
     s = settings_for_fleet("medium", 1)
     medium_dl = MARI_SCHEDULES["medium"].downlink_pps
-    assert s.inter_chunk_delay == pytest.approx(1.0 / (medium_dl * 0.5), rel=0.02)
+    assert s.inter_chunk_delay == pytest.approx(
+        1.0 / (medium_dl * OTA_DOWNLINK_UTILIZATION), rel=0.02
+    )
     assert s.block_size == 32
     # Report window comes from the schedule slotframe and grows with the fleet.
     assert settings_for_fleet("medium", 100).report_timeout > s.report_timeout

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -164,17 +164,30 @@ def test_block_layout_and_masks():
     assert bt.indices_from_mask(1, 0b1010) == [5, 7]
 
 
-def test_report_wait_scales_with_chunks_and_caps():
-    settings = BlockOTASettings(
+def test_report_wait_waits_for_residual_backlog():
+    # No pacing: wait covers the full drain of what was sent.
+    unpaced = BlockOTASettings(
         block_size=4,
         report_timeout=0.3,
         per_chunk_delivery=0.25,
+        inter_chunk_delay=0.0,
         wait_cap=12.0,
     )
-    bt, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=settings)
-    assert bt.report_wait(0) == pytest.approx(0.3)  # base only
-    assert bt.report_wait(4) == pytest.approx(0.3 + 4 * 0.25)  # scales
+    bt, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=unpaced)
+    assert bt.report_wait(0) == pytest.approx(0.3)  # nothing sent
+    assert bt.report_wait(4) == pytest.approx(0.3 + 4 * 0.25)  # full drain
     assert bt.report_wait(1000) == pytest.approx(12.0)  # capped
+
+    # Fully paced (delay >= drain): the send already drained it, so we wait
+    # only the report window regardless of how many chunks were sent.
+    paced = BlockOTASettings(
+        block_size=4,
+        report_timeout=0.3,
+        per_chunk_delivery=0.25,
+        inter_chunk_delay=0.25,
+    )
+    bt2, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=paced)
+    assert bt2.report_wait(32) == pytest.approx(0.3)
 
 
 def test_repair_mask_unions_reporting_devices():

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -12,7 +12,7 @@ import pytest
 
 from swarmit.testbed.ota import (
     BROADCAST_ADDRESS,
-    DEVICE_CHUNK_RATE_HZ,
+    MARI_SCHEDULES,
     BlockOTASettings,
     BlockTransfer,
     settings_for_fleet,
@@ -155,10 +155,12 @@ def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
 # --------------------------------------------------------------------------- #
 # Pure-helper tests.
 # --------------------------------------------------------------------------- #
-def test_settings_for_fleet_is_device_bound_today():
-    # Clamped to the device single-buffer rate: ~150 ms/chunk, block 32.
+def test_settings_for_fleet_derives_from_schedule():
+    # Default: radio downlink x utilization binds (device is fast enough now),
+    # ~24 ms/chunk on medium at util 0.5, block 32.
     s = settings_for_fleet("medium", 1)
-    assert s.inter_chunk_delay == pytest.approx(1.0 / DEVICE_CHUNK_RATE_HZ, rel=0.01)
+    medium_dl = MARI_SCHEDULES["medium"].downlink_pps
+    assert s.inter_chunk_delay == pytest.approx(1.0 / (medium_dl * 0.5), rel=0.02)
     assert s.block_size == 32
     # Report window comes from the schedule slotframe and grows with the fleet.
     assert settings_for_fleet("medium", 100).report_timeout > s.report_timeout
@@ -166,11 +168,11 @@ def test_settings_for_fleet_is_device_bound_today():
     assert settings_for_fleet("tiny", 1).report_timeout < s.report_timeout
 
 
-def test_settings_flip_lets_the_radio_bind():
-    # Raising the device rate (post-firmware) hands control to the radio x
-    # utilization term - injection gets much faster.
-    fast = settings_for_fleet("medium", 1, utilization=0.5, device_chunk_rate=1000)
-    assert fast.inter_chunk_delay < 0.03  # ~24 ms vs ~150 ms today
+def test_settings_device_rate_can_still_clamp():
+    # If a slower device rate is passed (e.g. a schedule/firmware regression),
+    # it clamps injection below the radio term.
+    slow = settings_for_fleet("medium", 1, utilization=1.0, device_chunk_rate=5.0)
+    assert slow.inter_chunk_delay == pytest.approx(1.0 / 5.0, rel=0.01)
 
 
 def test_block_layout_and_masks():

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -12,11 +12,8 @@ import pytest
 
 from swarmit.testbed.ota import (
     BROADCAST_ADDRESS,
-    MARI_SCHEDULES,
-    OTA_DOWNLINK_UTILIZATION,
     BlockOTASettings,
     BlockTransfer,
-    settings_for_fleet,
 )
 from swarmit.testbed.protocol import (
     PayloadOTABlockReportReq,
@@ -156,28 +153,6 @@ def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
 # --------------------------------------------------------------------------- #
 # Pure-helper tests.
 # --------------------------------------------------------------------------- #
-def test_settings_for_fleet_derives_from_schedule():
-    # Default: radio downlink x utilization binds (device is fast enough now),
-    # ~24 ms/chunk on medium at util 0.5, block 32.
-    s = settings_for_fleet("medium", 1)
-    medium_dl = MARI_SCHEDULES["medium"].downlink_pps
-    assert s.inter_chunk_delay == pytest.approx(
-        1.0 / (medium_dl * OTA_DOWNLINK_UTILIZATION), rel=0.02
-    )
-    assert s.block_size == 32
-    # Report window comes from the schedule slotframe and grows with the fleet.
-    assert settings_for_fleet("medium", 100).report_timeout > s.report_timeout
-    # A denser schedule (shorter slotframe) gives a shorter report window.
-    assert settings_for_fleet("tiny", 1).report_timeout < s.report_timeout
-
-
-def test_settings_device_rate_can_still_clamp():
-    # If a slower device rate is passed (e.g. a schedule/firmware regression),
-    # it clamps injection below the radio term.
-    slow = settings_for_fleet("medium", 1, utilization=1.0, device_chunk_rate=5.0)
-    assert slow.inter_chunk_delay == pytest.approx(1.0 / 5.0, rel=0.01)
-
-
 def test_block_layout_and_masks():
     image = make_image(10 * CHUNK_SIZE + 5)  # 11 chunks, W=4 -> 3 blocks
     bt, *_ = build(["AABB"], image)

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -1,0 +1,363 @@
+"""Unit tests for the block-OTA state machine (swarmit.testbed.ota).
+
+These drive the protocol logic against a fake transport with a scripted loss
+model and zero real time. Per the workspace no-mock rule they validate protocol
+*logic* only and do NOT stand in for on-hardware Mari validation.
+"""
+
+import dataclasses
+import hashlib
+
+import pytest
+
+from swarmit.testbed.ota import (
+    BROADCAST_ADDRESS,
+    BlockOTASettings,
+    BlockTransfer,
+)
+from swarmit.testbed.protocol import (
+    PayloadOTABlockReportReq,
+    PayloadOTAChunk,
+    PayloadOTAFinalize,
+)
+
+pytestmark = pytest.mark.transport_mock
+
+CHUNK_SIZE = 128
+
+
+@dataclasses.dataclass
+class SimpleChunk:
+    index: int
+    size: int
+    sha: bytes
+    data: bytes
+
+
+def make_chunks(image: bytes, chunk_size: int = CHUNK_SIZE) -> list[SimpleChunk]:
+    chunks = []
+    for i in range(0, len(image), chunk_size):
+        data = image[i : i + chunk_size]
+        sha = hashlib.sha256(data).digest()[:8]
+        chunks.append(
+            SimpleChunk(
+                index=i // chunk_size, size=len(data), sha=sha, data=data
+            )
+        )
+    return chunks
+
+
+def make_image(n_bytes: int) -> bytes:
+    # Deterministic, non-repeating enough that per-chunk shas differ.
+    return bytes((i * 31 + 7) & 0xFF for i in range(n_bytes))
+
+
+class FakeDevice:
+    """Mirrors the firmware's per-block mask bookkeeping."""
+
+    def __init__(self, addr: str, block_size: int):
+        self.addr = addr
+        self.w = block_size
+        self.received: set[int] = set()
+        self.block_index = 0
+        self.mask = 0
+
+    def deliver_chunk(self, index: int) -> None:
+        blk = index // self.w
+        if blk != self.block_index:
+            self.block_index = blk
+            self.mask = 0
+        self.mask |= 1 << (index % self.w)
+        self.received.add(index)
+
+    def report(self) -> tuple[int, int]:
+        return (self.block_index, self.mask)
+
+
+class FakeTransport:
+    """Delivers chunks/reports/finalize to fake devices with scripted loss.
+
+    ``chunk_loss(addr, index) -> bool`` and ``report_loss(addr, block) -> bool``
+    may be stateful (e.g. drop-once). ``report_loss`` also suppresses the
+    finalize response so a dead/silent bot never finalizes.
+    """
+
+    def __init__(
+        self,
+        devices,
+        block_size,
+        total_chunks,
+        chunk_loss=None,
+        report_loss=None,
+    ):
+        self.devices = {a: FakeDevice(a, block_size) for a in devices}
+        self.total_chunks = total_chunks
+        self.chunk_loss = chunk_loss or (lambda addr, index: False)
+        self.report_loss = report_loss or (lambda addr, block: False)
+        self.bt: BlockTransfer | None = None
+        self.chunk_sends = 0
+
+    def _targets(self, dest):
+        if dest == BROADCAST_ADDRESS:
+            return list(self.devices.items())
+        return [
+            (a, d) for a, d in self.devices.items() if int(a, 16) == dest
+        ]
+
+    def send_payload(self, dest, payload):
+        if isinstance(payload, PayloadOTAChunk):
+            self.chunk_sends += 1
+            for addr, dev in self._targets(dest):
+                if not self.chunk_loss(addr, payload.index):
+                    dev.deliver_chunk(payload.index)
+        elif isinstance(payload, PayloadOTABlockReportReq):
+            for addr, dev in self._targets(dest):
+                if not self.report_loss(addr, payload.block_index):
+                    block, mask = dev.report()
+                    self.bt.on_report(addr, block, mask)
+        elif isinstance(payload, PayloadOTAFinalize):
+            for addr, dev in self._targets(dest):
+                if self.report_loss(addr, -1):
+                    continue
+                self.bt.on_finalize_resp(
+                    addr, len(dev.received) == self.total_chunks
+                )
+
+
+def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
+    chunks = make_chunks(image)
+    settings = settings or BlockOTASettings(
+        block_size=4, inter_chunk_delay=0.0
+    )
+    transport = FakeTransport(
+        devices,
+        settings.block_size,
+        len(chunks),
+        chunk_loss=chunk_loss,
+        report_loss=report_loss,
+    )
+    progress = []
+    bt = BlockTransfer(
+        chunks=chunks,
+        devices=devices,
+        send_payload=transport.send_payload,
+        image_sha=hashlib.sha256(image).digest(),
+        settings=settings,
+        sleep=lambda *_: None,
+        on_progress=lambda a, i: progress.append((a, i)),
+    )
+    transport.bt = bt
+    return bt, transport, progress, chunks
+
+
+# --------------------------------------------------------------------------- #
+# Pure-helper tests.
+# --------------------------------------------------------------------------- #
+def test_block_layout_and_masks():
+    image = make_image(10 * CHUNK_SIZE + 5)  # 11 chunks, W=4 -> 3 blocks
+    bt, *_ = build(["AABB"], image)
+    assert bt.num_blocks == 3
+    assert list(bt.block_chunk_indices(0)) == [0, 1, 2, 3]
+    assert list(bt.block_chunk_indices(2)) == [8, 9, 10]  # partial last block
+    assert bt.full_block_mask(0) == 0b1111
+    assert bt.full_block_mask(2) == 0b111  # only 3 chunks
+    assert bt.indices_from_mask(1, 0b1010) == [5, 7]
+
+
+def test_round_wait_backoff_capped():
+    settings = BlockOTASettings(
+        block_size=4, report_timeout=0.26, backoff_cap=2.0
+    )
+    bt, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=settings)
+    assert bt.round_wait(0) == pytest.approx(0.26)
+    assert bt.round_wait(1) == pytest.approx(0.52)
+    assert bt.round_wait(10) == pytest.approx(2.0)  # capped
+
+
+def test_repair_mask_unions_reporting_devices():
+    image = make_image(4 * CHUNK_SIZE)  # one full block, W=4
+    bt, *_ = build(["AAAA", "BBBB"], image)
+    bt._reported = {"AAAA", "BBBB"}
+    bt._apply_confirmed("AAAA", 0, 0b0011)  # A has chunks 0,1
+    bt._apply_confirmed("BBBB", 0, 0b0101)  # B has chunks 0,2
+    # Union of missing: A misses 2,3 ; B misses 1,3 -> {1,2,3}
+    assert bt.repair_mask(0) == 0b1110
+
+
+def test_silent_device_contributes_no_repair():
+    image = make_image(4 * CHUNK_SIZE)
+    bt, *_ = build(["AAAA", "BBBB"], image)
+    # Only AAAA reported (missing chunk 3); BBBB is silent this block.
+    bt._reported = {"AAAA"}
+    bt._apply_confirmed("AAAA", 0, 0b0111)
+    # Repair only covers what AAAA reported missing; silence != full block.
+    assert bt.repair_mask(0) == 0b1000
+
+
+def test_earlier_reported_block_means_needs_full_block():
+    image = make_image(8 * CHUNK_SIZE)  # 2 blocks of 4
+    bt, transport, _, _ = build(["AAAA"], image)
+    bt._reset_block_state(1)
+    # Device reports it is still on block 0 while we evaluate block 1.
+    bt._round_reports = {"AAAA": (0, 0b1111)}
+    bt._evaluate_round(1)
+    # Reported but on an older block -> needs the whole current block.
+    assert bt.repair_mask(1) == bt.full_block_mask(1)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end convergence tests.
+# --------------------------------------------------------------------------- #
+def test_clean_path_single_bot_multi_block():
+    image = make_image(10 * CHUNK_SIZE + 20)  # 11 chunks
+    bt, transport, progress, chunks = build(["AABBCCDD"], image)
+    results = bt.run()
+    r = results["AABBCCDD"]
+    assert r.success
+    assert r.confirmed_chunks == len(chunks)
+    assert not r.straggler
+    # No loss: exactly one send per chunk.
+    assert transport.chunk_sends == len(chunks)
+    # Progress fired once per chunk.
+    assert len(progress) == len(chunks)
+
+
+def test_clean_path_multi_bot_broadcast():
+    image = make_image(9 * CHUNK_SIZE)
+    devices = ["1111", "2222", "3333"]
+    bt, transport, _, chunks = build(devices, image)
+    results = bt.run()
+    assert all(results[d].success for d in devices)
+    # Broadcast: one send per chunk covers all bots.
+    assert transport.chunk_sends == len(chunks)
+
+
+def test_recovers_from_chunk_loss_no_straggler():
+    image = make_image(8 * CHUNK_SIZE)  # 2 blocks
+    # Drop chunk 2 and chunk 5 exactly once each for the single bot.
+    drop = {("AAAA", 2), ("AAAA", 5)}
+
+    def chunk_loss(addr, index):
+        if (addr, index) in drop:
+            drop.discard((addr, index))
+            return True
+        return False
+
+    bt, transport, _, chunks = build(["AAAA"], image, chunk_loss=chunk_loss)
+    results = bt.run()
+    assert results["AAAA"].success
+    assert not results["AAAA"].straggler
+    # Two chunks were retransmitted once.
+    assert transport.chunk_sends == len(chunks) + 2
+
+
+def test_lost_report_costs_a_round_not_a_block():
+    image = make_image(4 * CHUNK_SIZE)  # single block
+    # Drop the bot's first report only; data all arrives.
+    state = {"dropped": False}
+
+    def report_loss(addr, block):
+        if block == 0 and not state["dropped"]:
+            state["dropped"] = True
+            return True
+        return False
+
+    bt, transport, _, chunks = build(["AAAA"], image, report_loss=report_loss)
+    results = bt.run()
+    assert results["AAAA"].success
+    # The block never had to be re-sent, only the report re-requested: still
+    # exactly one send per chunk.
+    assert transport.chunk_sends == len(chunks)
+
+
+def test_silent_bot_becomes_straggler_and_swarm_advances():
+    image = make_image(4 * CHUNK_SIZE)
+    good, dead = "600D", "DEAD"
+    devices = [good, dead]
+
+    # DEAD receives nothing and never reports; 600D is healthy.
+    def chunk_loss(addr, index):
+        return addr == dead
+
+    def report_loss(addr, block):
+        return addr == dead
+
+    settings = BlockOTASettings(
+        block_size=4,
+        inter_chunk_delay=0.0,
+        silent_straggler_rounds=3,
+        straggler_max_rounds=2,
+    )
+    bt, transport, _, chunks = build(
+        devices,
+        image,
+        settings=settings,
+        chunk_loss=chunk_loss,
+        report_loss=report_loss,
+    )
+    results = bt.run()
+    # Healthy bot completes; dead bot is a straggler and fails finalize, but
+    # the run terminates (swarm advanced past the silent bot).
+    assert results[good].success
+    assert results[dead].straggler
+    assert not results[dead].success
+    assert not results[dead].finalized
+
+
+def test_stall_bot_becomes_straggler():
+    image = make_image(4 * CHUNK_SIZE)
+
+    # The bot always misses chunk 3: every retransmit of it is lost, so its
+    # missing set never shrinks -> stall straggler after stall_straggler_rounds.
+    def chunk_loss(addr, index):
+        return index == 3
+
+    settings = BlockOTASettings(
+        block_size=4,
+        inter_chunk_delay=0.0,
+        stall_straggler_rounds=3,
+        straggler_max_rounds=1,
+        silent_straggler_rounds=99,
+    )
+    bt, transport, _, _ = build(
+        ["AAAA"], image, settings=settings, chunk_loss=chunk_loss
+    )
+    results = bt.run()
+    assert results["AAAA"].straggler
+    assert results["AAAA"].confirmed_chunks == 3  # got 0,1,2 not 3
+
+
+def test_unicast_straggler_recovery_succeeds():
+    image = make_image(4 * CHUNK_SIZE)
+
+    # Chunk 3 is lost during the broadcast phase but delivered during the
+    # unicast recovery pass (loss keyed to broadcast sends only).
+    phase = {"unicast": False}
+
+    def chunk_loss(addr, index):
+        return index == 3 and not phase["unicast"]
+
+    settings = BlockOTASettings(
+        block_size=4,
+        inter_chunk_delay=0.0,
+        stall_straggler_rounds=2,
+        silent_straggler_rounds=99,
+        straggler_max_rounds=3,
+    )
+    bt, transport, _, chunks = build(
+        ["AAAA"], image, settings=settings, chunk_loss=chunk_loss
+    )
+
+    # Flip to "unicast delivers" right when the recovery pass starts by wrapping
+    # the transport: the first unicast chunk send clears the loss.
+    orig_send = transport.send_payload
+
+    def wrapped(dest, payload):
+        if dest != BROADCAST_ADDRESS and isinstance(payload, PayloadOTAChunk):
+            phase["unicast"] = True
+        orig_send(dest, payload)
+
+    bt._send_payload = wrapped
+    results = bt.run()
+    assert results["AAAA"].success
+    assert not results["AAAA"].straggler

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -12,8 +12,10 @@ import pytest
 
 from swarmit.testbed.ota import (
     BROADCAST_ADDRESS,
+    DEVICE_CHUNK_RATE_HZ,
     BlockOTASettings,
     BlockTransfer,
+    settings_for_fleet,
 )
 from swarmit.testbed.protocol import (
     PayloadOTABlockReportReq,
@@ -153,6 +155,24 @@ def build(devices, image, settings=None, chunk_loss=None, report_loss=None):
 # --------------------------------------------------------------------------- #
 # Pure-helper tests.
 # --------------------------------------------------------------------------- #
+def test_settings_for_fleet_is_device_bound_today():
+    # Clamped to the device single-buffer rate: ~150 ms/chunk, block 32.
+    s = settings_for_fleet("medium", 1)
+    assert s.inter_chunk_delay == pytest.approx(1.0 / DEVICE_CHUNK_RATE_HZ, rel=0.01)
+    assert s.block_size == 32
+    # Report window comes from the schedule slotframe and grows with the fleet.
+    assert settings_for_fleet("medium", 100).report_timeout > s.report_timeout
+    # A denser schedule (shorter slotframe) gives a shorter report window.
+    assert settings_for_fleet("tiny", 1).report_timeout < s.report_timeout
+
+
+def test_settings_flip_lets_the_radio_bind():
+    # Raising the device rate (post-firmware) hands control to the radio x
+    # utilization term - injection gets much faster.
+    fast = settings_for_fleet("medium", 1, utilization=0.5, device_chunk_rate=1000)
+    assert fast.inter_chunk_delay < 0.03  # ~24 ms vs ~150 ms today
+
+
 def test_block_layout_and_masks():
     image = make_image(10 * CHUNK_SIZE + 5)  # 11 chunks, W=4 -> 3 blocks
     bt, *_ = build(["AABB"], image)

--- a/swarmit/tests/test_ota.py
+++ b/swarmit/tests/test_ota.py
@@ -164,14 +164,17 @@ def test_block_layout_and_masks():
     assert bt.indices_from_mask(1, 0b1010) == [5, 7]
 
 
-def test_round_wait_backoff_capped():
+def test_report_wait_scales_with_chunks_and_caps():
     settings = BlockOTASettings(
-        block_size=4, report_timeout=0.26, backoff_cap=2.0
+        block_size=4,
+        report_timeout=0.3,
+        per_chunk_delivery=0.25,
+        wait_cap=12.0,
     )
     bt, *_ = build(["AABB"], make_image(CHUNK_SIZE), settings=settings)
-    assert bt.round_wait(0) == pytest.approx(0.26)
-    assert bt.round_wait(1) == pytest.approx(0.52)
-    assert bt.round_wait(10) == pytest.approx(2.0)  # capped
+    assert bt.report_wait(0) == pytest.approx(0.3)  # base only
+    assert bt.report_wait(4) == pytest.approx(0.3 + 4 * 0.25)  # scales
+    assert bt.report_wait(1000) == pytest.approx(12.0)  # capped
 
 
 def test_repair_mask_unions_reporting_devices():

--- a/swarmit/tests/utils.py
+++ b/swarmit/tests/utils.py
@@ -200,8 +200,7 @@ class SwarmitNode(threading.Thread):
         elif payload_type == PayloadType.SWARMIT_OTA_FINALIZE:
             complete = (
                 len(self.received_chunks) == self.total_chunks
-                and self.ota_bytes_received
-                == self.ota_expected_bytes_received
+                and self.ota_bytes_received == self.ota_expected_bytes_received
             )
             ok = complete and not self.ota_should_fail
             self.send_packet(

--- a/swarmit/tests/utils.py
+++ b/swarmit/tests/utils.py
@@ -14,10 +14,13 @@ from marilib.mari_protocol import (
 from marilib.model import EdgeEvent, NodeInfoCloud
 from marilib.protocol import PacketType
 
+from swarmit.testbed.ota import BLOCK_SIZE_DEFAULT
 from swarmit.testbed.protocol import (
+    OTA_PROTOCOL_VERSION_BLOCK,
     DeviceType,
     PayloadEvent,
-    PayloadOTAChunkAck,
+    PayloadOTABlockReportResp,
+    PayloadOTAFinalizeResp,
     PayloadOTAStartAck,
     PayloadStatus,
     PayloadType,
@@ -26,16 +29,14 @@ from swarmit.testbed.protocol import (
 
 
 @dataclasses.dataclass
-class ChunkAckStrategy:
-    """Strategy for acknowledging OTA chunks."""
+class ChunkLossStrategy:
+    """Simulated downlink loss for a node during a block OTA transfer."""
 
-    ack_miss_index: int | None = None  # Index of chunk to skip acknowledgment
-    ack_miss_retries: int = (
-        0  # Number of retries before acknowledging the missed chunk
-    )
-    ack_out_of_range_index: int | None = (
-        None  # Index of chunk to send invalid acknowledgment
-    )
+    # Chunk index the node pretends never to receive...
+    drop_index: int | None = None
+    # ...for this many transmissions, after which it accepts the chunk. A
+    # count larger than the transfer's repair budget makes the loss permanent.
+    drop_count: int = 0
 
 
 class LogEventTask(threading.Thread):
@@ -78,8 +79,9 @@ class SwarmitNode(threading.Thread):
         device_type: DeviceType = DeviceType.Unknown,
         battery: int = 2500,
         update_interval: float = 0.1,
-        ack_strategy: ChunkAckStrategy = ChunkAckStrategy(),
+        loss_strategy: ChunkLossStrategy = ChunkLossStrategy(),
         ota_should_fail: bool = False,
+        ota_protocol_version: int = OTA_PROTOCOL_VERSION_BLOCK,
     ):
         self.adapter = adapter
         self.address = address
@@ -87,15 +89,23 @@ class SwarmitNode(threading.Thread):
         self.status = status
         self.battery = battery
         self.update_interval = update_interval
-        self.ack_strategy = ack_strategy
+        self.loss_strategy = loss_strategy
+        # Makes the node answer FINALIZE with ok=0 even if it got every chunk,
+        # standing in for an image that does not match the expected SHA256.
         self.ota_should_fail = ota_should_fail
+        self.ota_protocol_version = ota_protocol_version
         self._stop_event = threading.Event()
         super().__init__(daemon=True)
         self.enabled = True
         self.total_chunks = 0
-        self.last_chunk_acked = -1
         self.ota_bytes_received = 0
         self.ota_expected_bytes_received = 0
+        # Block-OTA device state, mirroring the bootloader: a set of chunk
+        # indices written to "flash", plus the per-block bitmap it reports.
+        self.received_chunks: set[int] = set()
+        self.block_index = 0
+        self.received_mask = 0
+        self._drops_left = 0
         self.start()
         self.log_event_task = LogEventTask(
             self,
@@ -148,36 +158,55 @@ class SwarmitNode(threading.Thread):
             self.status = StatusType.Programming
             self.total_chunks = packet.payload.fw_chunk_count
             self.ota_expected_bytes_received = packet.payload.fw_length
-            self.send_packet(Packet().from_payload(PayloadOTAStartAck()))
-        elif payload_type == PayloadType.SWARMIT_OTA_CHUNK:
-            # ack miss simulation
-            if self.ack_strategy.ack_miss_index == packet.payload.index:
-                if self.ack_strategy.ack_miss_retries > 0:
-                    self.ack_strategy.ack_miss_retries -= 1
-                    return
-
-            # only log index if not already acknowledged
-            if self.last_chunk_acked != packet.payload.index:
-                self.last_chunk_acked = packet.payload.index
-                self.ota_bytes_received += packet.payload.count
-
-            index_to_ack = packet.payload.index
-            if (
-                self.ack_strategy.ack_out_of_range_index
-                == packet.payload.index
-            ):
-                index_to_ack = self.total_chunks + 1
-            self.send_packet(
-                Packet().from_payload(PayloadOTAChunkAck(index=index_to_ack))
+            self.received_chunks = set()
+            self.block_index = 0
+            self.received_mask = 0
+            self._drops_left = self.loss_strategy.drop_count
+            # A pre-block bootloader sends the ack with no version byte, which
+            # the controller reads as version 1 and refuses to flash.
+            ack = (
+                PayloadOTAStartAck(version=self.ota_protocol_version)
+                if self.ota_protocol_version >= OTA_PROTOCOL_VERSION_BLOCK
+                else PayloadOTAStartAck()
             )
-            if (
-                index_to_ack == self.total_chunks - 1
-                and not self.ota_should_fail
-            ):
-                assert (
-                    self.ota_bytes_received == self.ota_expected_bytes_received
-                )
+            self.send_packet(Packet().from_payload(ack))
+        elif payload_type == PayloadType.SWARMIT_OTA_CHUNK:
+            index = packet.payload.index
+            # Simulated downlink loss: swallow the chunk without recording it.
+            if self.loss_strategy.drop_index == index and self._drops_left > 0:
+                self._drops_left -= 1
+                return
+            # No per-chunk ack: just write it and set the bitmap bit, resetting
+            # the mask when the window moves on (as the bootloader does).
+            if index not in self.received_chunks:
+                self.received_chunks.add(index)
+                self.ota_bytes_received += packet.payload.count
+            block = index // BLOCK_SIZE_DEFAULT
+            if block != self.block_index:
+                self.block_index = block
+                self.received_mask = 0
+            self.received_mask |= 1 << (index % BLOCK_SIZE_DEFAULT)
+            if len(self.received_chunks) == self.total_chunks:
                 self.status = StatusType.Bootloader
+        elif payload_type == PayloadType.SWARMIT_OTA_BLOCK_REPORT_REQ:
+            self.send_packet(
+                Packet().from_payload(
+                    PayloadOTABlockReportResp(
+                        block_index=self.block_index,
+                        received_mask=self.received_mask,
+                    )
+                )
+            )
+        elif payload_type == PayloadType.SWARMIT_OTA_FINALIZE:
+            complete = (
+                len(self.received_chunks) == self.total_chunks
+                and self.ota_bytes_received
+                == self.ota_expected_bytes_received
+            )
+            ok = complete and not self.ota_should_fail
+            self.send_packet(
+                Packet().from_payload(PayloadOTAFinalizeResp(ok=int(ok)))
+            )
 
     def send_packet(self, packet: Packet):
         self.adapter.handle_data_received(


### PR DESCRIPTION
## What

Replaces swarmit's per-chunk stop-and-wait OTA with a **block / bitmap-NACK** protocol. On hardware the 464-chunk / 59 KB lakers image goes from **~3.5 min to ~24 s**, finalize SHA-256 OK.

**Slides + charts (measured on hardware):** https://claude.ai/code/artifact/0d91acaa-8b49-44a4-b576-eb3033f51a6d

> [!IMPORTANT]
> **Bots must be re-provisioned before their next OTA flash** (`dotbot device flash-swarmit-sandbox`). The per-chunk path is gone from both sides, so this controller refuses a pre-block bootloader instead of falling back to it. That costs nothing in practice: the bootloader has always been flashed over J-Link during provisioning, never over the air, so no bot could have reached the new protocol by OTA anyway.

## Why

The old path sent one chunk, waited for an ack from every bot, then advanced - one Mari round trip per chunk, downlink idle in between. At scale a single straggler held the whole group.

## How it works

- Broadcast a block of chunks (W=32) at the downlink rate, **no per-chunk ack**; the netcore SHA-checks each and the bootloader writes it to flash.
- Each bot replies once with a **bitmap** of received chunks, in its own uplink slot (so collecting reports is O(1) in fleet size).
- Re-broadcast only the **union of still-missing** chunks; repeat until clean.
- **Finalize** each bot with a whole-image SHA-256 - a flash succeeds iff the image matches. The bitmap is a delivery signal; the SHA is the truth.

`OTA_START_ACK` still carries a protocol version, but as a **guard, not a fallback**: a bot that does not announce v2 aborts the flash with `StaleBootloaderError` before a single chunk goes on the wire, naming the bots and the re-provision command. The daemon and the local client surface the same thing as an error event.

Pacing is derived from the link the gateway is actually running, not from constants. `marilib.model.SCHEDULES` already holds the schedule geometry and the gateway reports its live `schedule_id`, so `adapter.py` turns that into a `LinkGeometry` and derives the inject rate (downlink capacity x 75% utilization, capped by the ~84 chunk/s a bot can absorb) and the report window. All the radio knowledge stays in the adapter - `ota.py` is transport-blind and just takes a settings object. The scaling factors are `ControllerSettings` fields on the usual CLI > TOML > defaults path (`ota_utilization`, `ota_device_chunk_rate`, `ota_report_timeout`).

## Results (HIL, remote Paris broker)

- lakers 59 KB: **~210 s (old baseline) -> 24 s**, ~9x. Effective throughput ~2 -> 19.5 chunk/s.
- rc-car (6.3 KB): ~15 s -> 4 s.
- The device's clean chunk-inject ceiling went **~13 -> ~84 chunk/s** once the per-chunk ack was removed - it had been pinning the transfer to the node's one-uplink-cell-per-slotframe rate.
- Finalize proven **authoritative** with a drop-one-chunk fault-injection run (`SWARMIT_OTA_TEST_DROP` -> `finalized=false`).

Note: these numbers predate the pacing change. Pacing now follows the schedule the gateway reports rather than an assumed "medium", so a desk running a different schedule will differ. Re-measurement on hardware is pending.

## Changes

**Firmware** (`device/`)

- Block-report + finalize handlers (netcore); received-bitmap and whole-image SHA-256 (bootloader); mutex-guarded shared chunk buffer.
- Per-chunk ack removed entirely. `ipc_ota_data_t` drops `protocol_version`, and `last_chunk_acked` becomes `last_chunk_seen` (it still drives the netcore's duplicate check; the old name lied once the acks were gone). Message id `0x87` stays reserved.
- `chunk_size` is now bounded against `SWRMT_OTA_CHUNK_SIZE` before it reaches either `memcpy` - it comes off the radio, and the per-chunk SHA is a detector, not a guard.

**Python** (`swarmit/`)

- New `ota.py` block-transfer state machine (transport- and clock-injected) + unit tests.
- `controller.transfer()` is block-only; `select_ota_path`, `send_chunk` and the per-chunk ack bookkeeping are gone. Images are padded to 4 bytes for word-granular flash writes.
- `LinkGeometry` + `derive_block_settings` on the adapter (see above).
- FINALIZE is unicast on a targeted transfer and on retries - broadcasting made untargeted bots hash their own unrelated flash and answer about it.
- Fixes the daemon's `/flash/stream`, which built its own `flash_started` event and never learned `block_size`/`n_blocks`, so flashing through `swarm serve` showed no block indicator.
- Loud failure logging with the missing-chunk list, plus a persistent logfmt file log at `~/.dotbot/logs/swarmit.log` (console stays at WARNING so structured logs no longer fight the progress bar).
- The fake node in `tests/utils.py` now speaks the block protocol (bitmap reports, finalize, simulated downlink loss), so the controller tests exercise the real path.

## Two crash fixes found on hardware

Bots dropped back to the bootloader a few seconds after `dotbot swarm start`, all reporting the same bare `crashed (watchdog0)` with no fault. It was two unrelated faults sharing one symptom, because every fault handler spins in `while(1)` and the watchdog always fires last and takes the blame.

**Misalignment - a regression in this branch.** The block-OTA fields grew `ipc_ota_data_t` by 41 bytes, an odd number, and `ipc_shared_data_t` is `packed`. That shifted `target_position`, `current_position`, `lh2_calibration` and `crash_report` off word alignment (`current_position` moved 292 -> 333), while the secure core word-accesses them with `SCB->CCR.UNALIGN_TRP` set. Any app reading its position took a secure HardFault on the first `swarmit_localization_get_position()`. `ipc_ota_data_t` is shared memory between the two cores and never serialized, so it does not need packing at all: unpacked, the compiler keeps its size a multiple of 4 by itself. `_Static_assert`s on the four members' alignment stop the class, since nothing else could catch a silent layout shift. Note the crash report was itself misaligned, so the diagnostic channel was riding on the bug it reported.

**Metrics probe misrouted - pre-existing, newly triggered.** `_handle_packet` claimed mari metrics probes with `length == sizeof(mr_metrics_payload_t)`. marilib's `MetricsProbePayload` has since grown four handover fields (115 -> 119 bytes), so the equality missed and the probe was forwarded to the user application every few seconds instead. That hangs any sandbox app whose `IPC_IRQHandler` is still the weak `dummy_handler` from dotbot-libs, which spins forever. Probes are now claimed on type alone and always consumed, and reported as metrics only when the frame is long enough for the fields written on the way back out - so a longer probe from a newer host stays usable instead of leaking into user code.

Found by bisecting sandbox images on bot `A23EFBCB596212AE`: `sample` ran forever while `rgbled` died, the `dotbot` app latched the faulting PC, and instrumenting an app's RX callback identified the stray frame as type `0x9C` at 119 bytes on the ~5 s cadence of `mari-edge -i 5`.

Follow-up, not in this PR: the mari submodule pin is behind the marilib the host runs, so those four handover fields are still dropped. And a sandbox app that omits `IPC_IRQHandler` can still be hung by genuine app-directed traffic - the fix for that belongs in the sandbox support layer, not in every app.

## Not yet done

- Re-measurement on hardware after the pacing change.
- Pipelining the per-block report barrier (next lever, aimed at ~10-15 s).
- Scale validation at 100+ bots (per the >=200-node rule before declaring the pacing tuned).
- Mirroring the changes into the `bootloader-single-core` target, which still carries the per-chunk path.

## Build / test

- All firmware targets build clean: bootloader `dotbot-v2` / `dotbot-v3` / `nrf5340dk`, netcore, mari gateway.
- 143 Python tests pass on Linux, macOS and Windows.
- Alignment fix validated on hardware: the `dotbot` app, which reads its position every 100 ms, runs indefinitely where it previously died in ~2.6 s. Post-fix struct offsets verified from DWARF on both cores and they match each other.
- The metrics-probe fix builds clean but still needs a net-core reflash to validate on hardware.


