### PR TITLE
swarmit: skip unflashable bots, and show sandbox firmware in status

### DIFF
--- a/swarmit/cli/main.py
+++ b/swarmit/cli/main.py
@@ -592,6 +592,12 @@ def flash(
                             )
                         )
                     return
+                elif etype == "warning":
+                    # Printed rather than raised: the flash continues without
+                    # the devices named here, and the operator has to see which.
+                    console.print(
+                        f"[bold yellow]Warning:[/] {ev.get('message', '')}"
+                    )
                 elif etype == "error":
                     if progress is not None:
                         progress.close()

--- a/swarmit/client/local.py
+++ b/swarmit/client/local.py
@@ -100,23 +100,45 @@ class LocalSwarmitClient:
 
         if start_data["missed"]:
             missed = sorted(set(start_data["missed"]))
+            if not start_data["acked"]:
+                yield {
+                    "type": "error",
+                    "message": f"{len(missed)} OTA start acks missed: {missed}",
+                }
+                return
+            # A bot that never answers the start - out of range, wedged, or on
+            # a bootloader that does not know this message - should cost itself
+            # the flash, not the rest of the fleet.
             yield {
-                "type": "error",
-                "message": f"{len(missed)} OTA start acks missed: {missed}",
+                "type": "warning",
+                "message": (
+                    f"skipping {len(missed)} device(s) that missed the OTA "
+                    f"start ack: {missed}"
+                ),
             }
-            return
 
         stale = self._controller.stale_bootloaders(start_data["acked"])
         if stale:
+            remaining = [d for d in start_data["acked"] if d not in set(stale)]
+            if not remaining:
+                yield {
+                    "type": "error",
+                    "message": (
+                        f"every target ({len(stale)}) runs a bootloader older "
+                        f"than the block OTA protocol: {stale}. Re-provision "
+                        "them with 'dotbot device flash-swarmit-sandbox'."
+                    ),
+                }
+                return
             yield {
-                "type": "error",
+                "type": "warning",
                 "message": (
-                    f"{len(stale)} device(s) run a bootloader older than the "
-                    f"block OTA protocol: {stale}. Re-provision them with "
-                    "'dotbot device flash-swarmit-sandbox'."
+                    f"skipping {len(stale)} device(s) on a bootloader older "
+                    f"than the block OTA protocol: {stale}. Re-provision them "
+                    "with 'dotbot device flash-swarmit-sandbox'."
                 ),
             }
-            return
+            start_data["acked"] = remaining
 
         block_size = self._controller.ota_block_size
         total_chunks = len(self._controller.chunks)

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -1575,17 +1575,28 @@ class Controller:
         their own progress (e.g. the daemon's /flash/stream or
         LocalSwarmitClient.flash) pass False to avoid duplicate output.
 
-        Raises ``StaleBootloaderError`` if any target bot still runs a
-        pre-block bootloader, before a single chunk goes on the wire.
+        Bots on a pre-block bootloader are skipped rather than failing the
+        run: one un-reprovisioned bot in a fleet of a hundred should not cost
+        the other ninety-nine their flash. ``StaleBootloaderError`` is still
+        raised when *every* target is stale, since then there is nothing to
+        transfer and the caller asked for something impossible.
         """
         stale = self.stale_bootloaders(devices)
         if stale:
-            self.logger.error(
-                "ota aborted: stale bootloaders",
+            remaining = [d for d in devices if d not in set(stale)]
+            if not remaining:
+                self.logger.error(
+                    "ota aborted: every target has a stale bootloader",
+                    devices=stale,
+                    required_version=OTA_PROTOCOL_VERSION_BLOCK,
+                )
+                raise StaleBootloaderError(stale)
+            self.logger.warning(
+                "ota skipping stale bootloaders",
                 devices=stale,
                 required_version=OTA_PROTOCOL_VERSION_BLOCK,
             )
-            raise StaleBootloaderError(stale)
+            devices = remaining
         data_size = len(firmware)
         use_progress_bar = show_progress and not self.settings.verbose
         progress = None

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -10,7 +10,8 @@ from dataclasses import dataclass
 from cryptography.hazmat.primitives import hashes
 from dotbot_utils.protocol import Packet, Payload
 from dotbot_utils.serial_interface import get_default_port
-from rich import print
+from rich import get_console, print
+from rich.columns import Columns
 from rich.console import Group
 from rich.live import Live
 from rich.panel import Panel
@@ -457,6 +458,67 @@ def format_sandbox_fw(info: DeviceInfo | None) -> str:
     return version
 
 
+FW_CELL = 6  # index of the sandbox-fw cell in a status row
+
+
+def _status_table(rows, show_fw: bool = True) -> Table:
+    """One status table over `rows`, each a tuple of preformatted cells."""
+    table = Table()
+    table.add_column("Device Addr", style="magenta", no_wrap=True)
+    table.add_column("Type", style="cyan", justify="center")
+    table.add_column("Battery", style="cyan", justify="center")
+    table.add_column("Position", style="cyan", justify="center")
+    table.add_column(
+        "Status",
+        style="green",
+        justify="center",
+        width=max([len(m) for m in StatusType.__members__]),
+    )
+    table.add_column("Image", style="cyan", justify="center")
+    if show_fw:
+        table.add_column("Sandbox fw (bl / net)", style="cyan", justify="center")
+    table.add_column("Last reset", style="cyan", justify="center")
+    for row in rows:
+        table.add_row(*(row if show_fw else row[:FW_CELL] + row[FW_CELL + 1 :]))
+    return table
+
+
+def _status_columns(rows, show_fw: bool = True, console=None):
+    """Lay the rows out in newspaper columns when one table would not fit.
+
+    A hundred-bot fleet is one row per bot and far taller than any terminal,
+    while the table itself uses maybe half the width - so the run scrolls off
+    the top with the right-hand side of the screen empty. Split the rows
+    across side-by-side tables instead, as many as fit the width and only as
+    many as the height actually needs.
+
+    Below that threshold nothing changes: one table, exactly as before.
+    """
+    console = console or get_console()
+    single = _status_table(rows, show_fw=show_fw)
+    if not rows:
+        return single
+
+    table_width = console.measure(single).maximum
+    gap = 2
+    fit_across = (console.width + gap) // (table_width + gap)
+    # Header, borders and the surrounding blank lines cost about this much.
+    body_height = max(1, console.size.height - 8)
+    needed = -(-len(rows) // body_height)  # ceil
+
+    n = max(1, min(fit_across, needed, len(rows)))
+    if n <= 1:
+        return single
+
+    per = -(-len(rows) // n)  # ceil, so the last column is the short one
+    chunks = [rows[i : i + per] for i in range(0, len(rows), per)]
+    return Columns(
+        [_status_table(chunk, show_fw=show_fw) for chunk in chunks],
+        padding=(0, 1),
+        expand=False,
+    )
+
+
 def generate_status(status_data, devices=[], status_message="found"):
     data = {
         addr: device_data
@@ -470,46 +532,9 @@ def generate_status(status_data, devices=[], status_message="found"):
         f"\n{len(data)} device{'s' if len(data) > 1 else ''} {status_message}\n"
     )
 
-    table = Table()
-    table.add_column("Device Addr", style="magenta", no_wrap=True)
-    table.add_column(
-        "Type",
-        style="cyan",
-        justify="center",
-    )
-    table.add_column(
-        "Battery",
-        style="cyan",
-        justify="center",
-    )
-    table.add_column(
-        "Position",
-        style="cyan",
-        justify="center",
-    )
-    table.add_column(
-        "Status",
-        style="green",
-        justify="center",
-        width=max([len(m) for m in StatusType.__members__]),
-    )
-    table.add_column(
-        "Image",
-        style="cyan",
-        justify="center",
-    )
-    table.add_column(
-        "Sandbox fw (bl / net)",
-        style="cyan",
-        justify="center",
-    )
-    table.add_column(
-        "Last reset",
-        style="cyan",
-        justify="center",
-    )
     majority, odd_ones = image_mismatches(data)
     odd_addrs = {addr for addr, _ in odd_ones}
+    rows = []
     for device_addr, device_data in sorted(data.items()):
         info = device_data.info
         # "-" means the bot has not answered yet, which is what an older
@@ -519,16 +544,34 @@ def generate_status(status_data, devices=[], status_message="found"):
         if device_addr in odd_addrs:
             image = f"[yellow]{image}"
 
-        table.add_row(
-            f"{device_addr}",
-            f"{device_data.device.name}",
-            f"[{battery_level_color(device_data.battery)}]{device_data.battery / 1000:.2f}V ({int(device_data.battery / 3000 * 100)}%)",
-            f"({device_data.pos_x}, {device_data.pos_y})",
-            f"{'[bold cyan]' if device_data.status == StatusType.Running else '[bold green]'}{device_data.status.name}",
-            image,
-            format_sandbox_fw(info),
-            f"[{reset_cause_color(device_data)}]{format_reset_cause(device_data)}",
+        rows.append(
+            (
+                f"{device_addr}",
+                f"{device_data.device.name}",
+                f"[{battery_level_color(device_data.battery)}]{device_data.battery / 1000:.2f}V ({int(device_data.battery / 3000 * 100)}%)",
+                f"({device_data.pos_x}, {device_data.pos_y})",
+                f"{'[bold cyan]' if device_data.status == StatusType.Running else '[bold green]'}{device_data.status.name}",
+                image,
+                format_sandbox_fw(info),
+                f"[{reset_cause_color(device_data)}]{format_reset_cause(device_data)}",
+            )
         )
+
+    # A fleet is normally flashed in one go, so the sandbox version is the same
+    # string on every row - 34 columns spent to say one thing N times, and the
+    # width that decides whether the table can be laid out side by side. State
+    # it once above the table instead, and keep the column only when the fleet
+    # actually disagrees, which is the case worth a column.
+    fw_values = {row[FW_CELL] for row in rows}
+    show_fw = len(fw_values) > 1
+    if not show_fw:
+        only = next(iter(fw_values))
+        if only != "-":
+            header = Text.assemble(
+                header, Text.from_markup(f"Sandbox fw (bl / net): {only}\n")
+            )
+
+    table = _status_columns(rows, show_fw=show_fw)
     if not odd_ones:
         return Group(header, table)
 

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -415,6 +415,25 @@ def image_mismatches(status_data) -> tuple[str, list[tuple[str, DeviceInfo]]]:
     return majority, odd
 
 
+def format_sandbox_fw(info: DeviceInfo | None) -> str:
+    """One column for the bootloader and net-core versions.
+
+    They are built and flashed together, so the two agreeing is the normal
+    case and printing both would cost width on every row to say the same
+    thing twice. Collapse them when they match, and show both when they do
+    not - a disagreement means a half-finished flash, which is the reason to
+    have the column at all.
+    """
+    if info is None:
+        return "-"
+    bl, net = info.bl_version, info.net_version
+    if not bl and not net:
+        return "-"
+    if bl == net:
+        return bl
+    return f"[yellow]bl {bl or '?'} / net {net or '?'}"
+
+
 def generate_status(status_data, devices=[], status_message="found"):
     data = {
         addr: device_data
@@ -457,6 +476,11 @@ def generate_status(status_data, devices=[], status_message="found"):
         justify="center",
     )
     table.add_column(
+        "Sandbox fw",
+        style="cyan",
+        justify="center",
+    )
+    table.add_column(
         "Last reset",
         style="cyan",
         justify="center",
@@ -479,6 +503,7 @@ def generate_status(status_data, devices=[], status_message="found"):
             f"({device_data.pos_x}, {device_data.pos_y})",
             f"{'[bold cyan]' if device_data.status == StatusType.Running else '[bold green]'}{device_data.status.name}",
             image,
+            format_sandbox_fw(info),
             f"[{reset_cause_color(device_data)}]{format_reset_cause(device_data)}",
         )
     if not odd_ones:

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -415,23 +415,46 @@ def image_mismatches(status_data) -> tuple[str, list[tuple[str, DeviceInfo]]]:
     return majority, odd
 
 
+def _split_dirty(version: str) -> tuple[str, bool]:
+    """Separate a `git describe --dirty` version from its dirty marker."""
+    if version.endswith("-dirty"):
+        return version[: -len("-dirty")], True
+    return version, False
+
+
 def format_sandbox_fw(info: DeviceInfo | None) -> str:
     """One column for the bootloader and net-core versions.
 
     They are built and flashed together, so the two agreeing is the normal
-    case and printing both would cost width on every row to say the same
-    thing twice. Collapse them when they match, and show both when they do
-    not - a disagreement means a half-finished flash, which is the reason to
-    have the column at all.
+    case and printing both in full would spend ~50 columns on every row to
+    say the same thing twice. Collapse them when they agree and show both
+    when they do not - a real disagreement means a half-finished flash, which
+    is the reason to have the column at all.
+
+    `-dirty` is build state rather than a different version, so it is compared
+    out and reported as a flag. Otherwise a net core built from an uncommitted
+    tree - the normal case at the bench - would look like a version mismatch
+    and defeat the collapse on every row.
     """
     if info is None:
         return "-"
     bl, net = info.bl_version, info.net_version
     if not bl and not net:
         return "-"
-    if bl == net:
-        return bl
-    return f"[yellow]bl {bl or '?'} / net {net or '?'}"
+
+    bl_base, bl_dirty = _split_dirty(bl)
+    net_base, net_dirty = _split_dirty(net)
+    if bl_base != net_base:
+        return f"[yellow]{bl or '?'} / {net or '?'}"
+
+    version = bl_base or net_base
+    if bl_dirty and net_dirty:
+        return f"{version} [yellow](dirty)"
+    if bl_dirty:
+        return f"{version} [yellow](bl dirty)"
+    if net_dirty:
+        return f"{version} [yellow](net dirty)"
+    return version
 
 
 def generate_status(status_data, devices=[], status_message="found"):
@@ -476,7 +499,7 @@ def generate_status(status_data, devices=[], status_message="found"):
         justify="center",
     )
     table.add_column(
-        "Sandbox fw",
+        "Sandbox fw (bl / net)",
         style="cyan",
         justify="center",
     )

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -476,10 +476,14 @@ def _status_table(rows, show_fw: bool = True) -> Table:
     )
     table.add_column("Image", style="cyan", justify="center")
     if show_fw:
-        table.add_column("Sandbox fw (bl / net)", style="cyan", justify="center")
+        table.add_column(
+            "Sandbox fw (bl / net)", style="cyan", justify="center"
+        )
     table.add_column("Last reset", style="cyan", justify="center")
     for row in rows:
-        table.add_row(*(row if show_fw else row[:FW_CELL] + row[FW_CELL + 1 :]))
+        table.add_row(
+            *(row if show_fw else row[:FW_CELL] + row[FW_CELL + 1 :])
+        )
     return table
 
 

--- a/swarmit/testbed/webserver.py
+++ b/swarmit/testbed/webserver.py
@@ -373,30 +373,58 @@ async def flash_stream(payload: FlashRequest, request: Request):
             return
 
         if start_data["missed"]:
+            missed = sorted(set(start_data["missed"]))
+            if not start_data["acked"]:
+                yield _sse(
+                    {
+                        "type": "error",
+                        "message": (
+                            f"{len(missed)} OTA start acks missed: {missed}"
+                        ),
+                    }
+                )
+                return
+            # A bot that never answers the start - out of range, wedged, or on
+            # a bootloader that does not know this message - should cost itself
+            # the flash, not the rest of the fleet.
             yield _sse(
                 {
-                    "type": "error",
+                    "type": "warning",
                     "message": (
-                        f"{len(start_data['missed'])} OTA start acks "
-                        f"missed: {sorted(set(start_data['missed']))}"
+                        f"skipping {len(missed)} device(s) that missed the "
+                        f"OTA start ack: {missed}"
                     ),
                 }
             )
-            return
 
         stale = controller.stale_bootloaders(start_data["acked"])
         if stale:
+            remaining = [d for d in start_data["acked"] if d not in set(stale)]
+            if not remaining:
+                yield _sse(
+                    {
+                        "type": "error",
+                        "message": (
+                            f"every target ({len(stale)}) runs a bootloader "
+                            f"older than the block OTA protocol: {stale}. "
+                            "Re-provision them with 'dotbot device "
+                            "flash-swarmit-sandbox'."
+                        ),
+                    }
+                )
+                return
             yield _sse(
                 {
-                    "type": "error",
+                    "type": "warning",
                     "message": (
-                        f"{len(stale)} device(s) run a bootloader older than "
-                        f"the block OTA protocol: {stale}. Re-provision them "
-                        "with 'dotbot device flash-swarmit-sandbox'."
+                        f"skipping {len(stale)} device(s) on a bootloader "
+                        f"older than the block OTA protocol: {stale}. "
+                        "Re-provision them with 'dotbot device "
+                        "flash-swarmit-sandbox'."
                     ),
                 }
             )
-            return
+            start_data["acked"] = remaining
 
         block_size = controller.ota_block_size
         total_chunks = len(controller.chunks)

--- a/swarmit/tests/test_client.py
+++ b/swarmit/tests/test_client.py
@@ -238,17 +238,64 @@ def test_local_context_manager_terminates(controller_mock):
     inst.terminate.assert_called_once()
 
 
-@patch("swarmit.client.local.Controller")
-def test_local_flash_emits_error_on_missed_acks(controller_mock):
+def _flash_controller(controller_mock, acked, missed=(), stale=()):
+    """Wire a mocked Controller for a flash that reaches the transfer."""
     inst = controller_mock.return_value
     inst.start_ota.return_value = {
         "ota": MagicMock(fw_hash=b"\x00" * 32),
-        "acked": ["A"],
-        "missed": ["B"],
+        "acked": list(acked),
+        "missed": list(missed),
     }
+    # Set even when empty: an unconfigured MagicMock is truthy but iterates
+    # empty, which fakes a "skipping 0 device(s)" stale-bootloader warning.
+    inst.stale_bootloaders.return_value = list(stale)
     inst.chunks = [MagicMock()]
+    return inst
+
+
+@patch("swarmit.client.local.Controller")
+def test_local_flash_errors_when_no_device_acked_the_start(controller_mock):
+    _flash_controller(controller_mock, acked=[], missed=["B"])
     client = LocalSwarmitClient(ControllerSettings())
     events = list(client.flash(b"fw"))
     assert len(events) == 1
     assert events[0]["type"] == "error"
     assert "missed" in events[0]["message"]
+
+
+@patch("swarmit.client.local.Controller")
+def test_local_flash_skips_devices_that_missed_the_start_ack(controller_mock):
+    _flash_controller(controller_mock, acked=["A"], missed=["B"])
+    client = LocalSwarmitClient(ControllerSettings())
+    events = list(client.flash(b"fw"))
+    assert events[0]["type"] == "warning"
+    assert "B" in events[0]["message"]
+    assert not [e for e in events if e["type"] == "error"]
+    started = [e for e in events if e["type"] == "flash_started"]
+    assert len(started) == 1
+    assert started[0]["devices"] == ["A"]
+
+
+@patch("swarmit.client.local.Controller")
+def test_local_flash_errors_when_every_bootloader_is_stale(controller_mock):
+    _flash_controller(controller_mock, acked=["A"], stale=["A"])
+    client = LocalSwarmitClient(ControllerSettings())
+    events = list(client.flash(b"fw"))
+    assert len(events) == 1
+    assert events[0]["type"] == "error"
+    assert "bootloader older" in events[0]["message"]
+
+
+@patch("swarmit.client.local.Controller")
+def test_local_flash_skips_stale_bootloaders_and_flashes_the_rest(
+    controller_mock,
+):
+    _flash_controller(controller_mock, acked=["A", "B"], stale=["B"])
+    client = LocalSwarmitClient(ControllerSettings())
+    events = list(client.flash(b"fw"))
+    assert events[0]["type"] == "warning"
+    assert "B" in events[0]["message"]
+    assert not [e for e in events if e["type"] == "error"]
+    started = [e for e in events if e["type"] == "flash_started"]
+    assert len(started) == 1
+    assert started[0]["devices"] == ["A"]


### PR DESCRIPTION
Two things that surfaced while provisioning and flashing a ~100-bot DotBot
fleet in one sitting.

## A flash no longer fails because of one bot

Flashing the fleet aborted outright when a single bot could not take the
image. One robot that had never been re-provisioned cost the other ninety-nine
their flash, and the only way through was to hand-build a device list that
excluded it - from a status table of a hundred rows.

Two separate gates did this, and both are now skip-and-report. A bot that
misses the OTA start ack (out of range, wedged, or on a bootloader that does
not know the message) is named and left out. A bot on a pre-block bootloader
is likewise named and left out. Either way the transfer proceeds with the bots
that answered, and both still raise when *nothing* is left to flash, so a
genuinely impossible request fails loudly rather than reporting success over
zero devices.

The skip is a `warning` event the CLI renders in yellow, not a silent drop -
the operator has to see which robots did not get the image. All three paths
that enforced this are covered: the in-process client, the daemon's
`/flash/stream`, and `Controller.transfer` itself as a backstop.

Worth calling out as a behaviour change for anyone scripting against it: a
flash that used to abort now returns success having skipped devices.

## `status` shows which firmware each bot is running

The bootloader and net-core versions were already on the wire and already
parsed - `info` rendered them, `status` did not. Adding the column needed no
protocol or firmware change and no extra round trip.

It is one column rather than two because the two cores are built and flashed
together, so agreement is the normal case and printing both in full would
spend width on every row to say the same thing twice. They collapse when they
agree and expand to `bl X / net Y` in yellow when they do not - a real
disagreement means a half-finished flash. `-dirty` is compared out and shown
as a flag, otherwise a net core built from an uncommitted tree reads as a
version mismatch on every row and the collapse never fires.

That collapse is also what makes the last commit possible. A hundred-bot fleet
is a hundred rows and scrolls off the top while the right-hand side of the
terminal sits empty, but two tables side by side only fit once the table is
narrow enough: hoisting the uniform version above the table takes it from 126
to 91 columns, so a second table lands at 190 rather than needing 254. Splits
only when it helps - column count is capped by what the height actually needs,
and below the threshold the output is unchanged.

## Validation

`hatch test` / pytest: 184 passed.

Exercised on the ~100-bot fleet. Before that, on a three-device flash
targeting two current bots and one pre-block bootloader, which printed
`Warning: skipping 1 device(s) that missed the OTA start ack` and completed
`2/2 ok`. Note the missed-ack gate is the one that fires for such a bot - it
never answers the new start at all, so it aborts there before the
stale-bootloader check is reached.

Neither gate had test coverage before this change. Both now have it, in
`swarmit/tests/test_client.py`: each of the missed-ack and stale-bootloader
gates is covered in its partial-skip form (warns, flashes the rest) and its
nothing-left-to-flash form (errors, stops).
