### PR TITLE
device: capture where the app was when the watchdog fires

### DIFF
--- a/device/bootloader/Source/ipc.h
+++ b/device/bootloader/Source/ipc.h
@@ -109,6 +109,8 @@ typedef struct __attribute__((packed)) {
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault
     uint32_t lr;            ///< Stacked link register at fault
+    uint32_t sp;            ///< Stack pointer of the interrupted context (its exception frame address)
+    uint32_t psr;           ///< Stacked xPSR; IPSR field names the active exception, 0 for thread mode
 } ipc_crash_report_t;
 
 typedef struct __attribute__((packed,aligned(8))) {

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -343,6 +343,8 @@ int main(void) {
         ipc_shared_data.crash_report.sfsr    = crash_latch.sfsr;
         ipc_shared_data.crash_report.pc      = crash_latch.pc;
         ipc_shared_data.crash_report.lr      = crash_latch.lr;
+        ipc_shared_data.crash_report.sp      = crash_latch.sp;
+        ipc_shared_data.crash_report.psr     = crash_latch.psr;
     } else {
         // ipc_shared_data lives in .shared_data, which is load="No" and outside
         // the startup zeroing loops, so these fields otherwise keep the previous
@@ -356,6 +358,8 @@ int main(void) {
         ipc_shared_data.crash_report.sfsr    = 0;
         ipc_shared_data.crash_report.pc      = 0;
         ipc_shared_data.crash_report.lr      = 0;
+        ipc_shared_data.crash_report.sp      = 0;
+        ipc_shared_data.crash_report.psr     = 0;
     }
     crash_latch.magic = 0;
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -115,6 +115,22 @@ static void setup_watchdog0(void) {
 
     // Configure timeout and callback
     NRF_WDT0_S->CRV = 32768 - 1;
+
+    // Take the TIMEOUT interrupt: it is what postpones the reset by two
+    // 32.768 kHz cycles, and that window is the only chance to record where the
+    // application was when its deadline blew. The reset still lands, so this
+    // only ever adds a diagnostic. Priority 0 matches SecureFault's default, so
+    // a fault handler already spinning for this timeout is never preempted and
+    // its richer snapshot survives. WDT0 stays secure - no NVIC_SetTargetState -
+    // so non-secure code can reach neither the peripheral nor its interrupt.
+    // Configured before TASKS_START: CRV, RREN and CONFIG are blocked for
+    // reconfiguration once the watchdog runs.
+    NRF_WDT0_S->EVENTS_TIMEOUT = 0;
+    NRF_WDT0_S->INTENSET = WDT_INTENSET_TIMEOUT_Enabled << WDT_INTENSET_TIMEOUT_Pos;
+    NVIC_SetPriority(WDT0_IRQn, 0);
+    NVIC_ClearPendingIRQ(WDT0_IRQn);
+    NVIC_EnableIRQ(WDT0_IRQn);
+
     NRF_WDT0_S->TASKS_START = WDT_TASKS_START_TASKS_START_Trigger << WDT_TASKS_START_TASKS_START_Pos;
 }
 

--- a/device/bootloader/Source/main.c
+++ b/device/bootloader/Source/main.c
@@ -343,6 +343,19 @@ int main(void) {
         ipc_shared_data.crash_report.sfsr    = crash_latch.sfsr;
         ipc_shared_data.crash_report.pc      = crash_latch.pc;
         ipc_shared_data.crash_report.lr      = crash_latch.lr;
+    } else {
+        // ipc_shared_data lives in .shared_data, which is load="No" and outside
+        // the startup zeroing loops, so these fields otherwise keep the previous
+        // boot's snapshot - or uninitialized RAM on a cold boot, where a random
+        // non-zero fault byte reports a crash on a device that was just switched
+        // on. Without a latch there is nothing to report, and saying so beats
+        // reporting a fault that did not happen.
+        ipc_shared_data.crash_report.fault   = CRASH_FAULT_NONE;
+        ipc_shared_data.crash_report.from_ns = 0;
+        ipc_shared_data.crash_report.cfsr    = 0;
+        ipc_shared_data.crash_report.sfsr    = 0;
+        ipc_shared_data.crash_report.pc      = 0;
+        ipc_shared_data.crash_report.lr      = 0;
     }
     crash_latch.magic = 0;
 

--- a/device/bootloader/System/crash_latch.h
+++ b/device/bootloader/System/crash_latch.h
@@ -34,6 +34,8 @@ typedef struct {
     uint32_t sfsr;     ///< Secure Fault Status Register
     uint32_t pc;       ///< Stacked program counter at fault (0 if unavailable)
     uint32_t lr;       ///< Stacked link register at fault (0 if unavailable)
+    uint32_t sp;       ///< Stack pointer of the interrupted context, i.e. the address of its exception frame
+    uint32_t psr;      ///< Stacked xPSR; its IPSR field names the exception that was active, 0 for thread mode
 } crash_latch_t;
 
 extern volatile crash_latch_t crash_latch;

--- a/device/bootloader/System/crash_latch.h
+++ b/device/bootloader/System/crash_latch.h
@@ -20,9 +20,10 @@
 #define CRASH_LATCH_MAGIC (0xFA170BADUL)
 
 typedef enum {
-    CRASH_FAULT_NONE   = 0,  ///< No fault caught - clean reset (power-on, pin, stop, soft-reset)
-    CRASH_FAULT_HARD   = 1,  ///< Secure HardFault, e.g. a bus/usage fault escalated in secure or NSC code
-    CRASH_FAULT_SECURE = 2,  ///< SecureFault, e.g. the app writing into secure memory (a NULL store hits AUVIOL)
+    CRASH_FAULT_NONE     = 0,  ///< No fault caught - clean reset (power-on, pin, stop, soft-reset)
+    CRASH_FAULT_HARD     = 1,  ///< Secure HardFault, e.g. a bus/usage fault escalated in secure or NSC code
+    CRASH_FAULT_SECURE   = 2,  ///< SecureFault, e.g. the app writing into secure memory (a NULL store hits AUVIOL)
+    CRASH_FAULT_WATCHDOG = 3,  ///< WDT0 timed out - no fault was raised, the app stopped reloading it
 } crash_fault_t;
 
 typedef struct {
@@ -48,5 +49,22 @@ extern volatile crash_latch_t crash_latch;
  *                          whether the faulting context was secure
  */
 void crash_latch_fault(uint32_t fault, uint32_t *sp, uint32_t exc_return);
+
+/**
+ * @brief Snapshot the interrupted context when WDT0 times out
+ *
+ * Enabling WDT0's TIMEOUT interrupt postpones the watchdog reset by two
+ * 32.768 kHz cycles (~61 us), which is the whole window this has to record
+ * where the application was stuck. The reset is not cancellable, so this only
+ * ever adds a diagnostic.
+ *
+ * Leaves an already-valid latch alone: a fault handler that latched is spinning
+ * on purpose, waiting for exactly this timeout, and its snapshot is the
+ * interesting one.
+ *
+ * @param[in]   sp          Stack frame of the interrupted context
+ * @param[in]   exc_return  EXC_RETURN seen on handler entry
+ */
+void crash_latch_watchdog(uint32_t *sp, uint32_t exc_return);
 
 #endif  // __CRASH_LATCH_H

--- a/device/bootloader/System/fault_handlers.c
+++ b/device/bootloader/System/fault_handlers.c
@@ -22,12 +22,19 @@ void crash_latch_fault(uint32_t fault, uint32_t *sp, uint32_t exc_return) {
     crash_latch.sfsr    = SCB->SFSR;
     crash_latch.pc      = 0;
     crash_latch.lr      = 0;
+    crash_latch.psr     = 0;
+    // The frame address is the interrupted context's stack pointer, and unlike
+    // the words inside the frame it costs no dereference - so it is recorded
+    // before the magic, and survives even a stacking error that makes the rest
+    // unreadable.
+    crash_latch.sp = (uint32_t)sp;
     // Magic is set before touching the stacked frame: reading it can fault
     // again (e.g. after a stacking error), in which case the latch stays
-    // valid with pc/lr zeroed.
+    // valid with pc/lr/psr zeroed.
     crash_latch.magic = CRASH_LATCH_MAGIC;
     crash_latch.lr    = sp[5];
     crash_latch.pc    = sp[6];
+    crash_latch.psr   = sp[7];
 }
 
 void crash_latch_watchdog(uint32_t *sp, uint32_t exc_return) {

--- a/device/bootloader/System/fault_handlers.c
+++ b/device/bootloader/System/fault_handlers.c
@@ -30,6 +30,21 @@ void crash_latch_fault(uint32_t fault, uint32_t *sp, uint32_t exc_return) {
     crash_latch.pc    = sp[6];
 }
 
+void crash_latch_watchdog(uint32_t *sp, uint32_t exc_return) {
+    NRF_WDT0_S->EVENTS_TIMEOUT = 0;
+    // A fault handler that already latched is spinning on purpose, waiting for
+    // exactly this timeout. Its snapshot names the fault; this one would only
+    // name the spin loop.
+    if (crash_latch.magic != CRASH_LATCH_MAGIC) {
+        crash_latch_fault(CRASH_FAULT_WATCHDOG, sp, exc_return);
+    }
+    // The reset is already committed - two 32.768 kHz cycles from the TIMEOUT
+    // event - so there is nothing to return to.
+    while (1) {
+        __NOP();
+    }
+}
+
 void HardFaultHandler(uint32_t *sp, uint32_t exc_return) {
     if (SCB->HFSR & (SCB_HFSR_DEBUGEVT_Msk)) {
         SCB->HFSR |=  (SCB_HFSR_DEBUGEVT_Msk);      // Reset Hard Fault status

--- a/device/bootloader/System/startup.c
+++ b/device/bootloader/System/startup.c
@@ -74,6 +74,10 @@ __attribute__ ((weak, alias("Dummy_Handler"))) void SysTick_Handler(void);
 
 void HardFault_Handler(void);
 void SecureFault_Handler(void);
+// Strong definition below, so it must not also appear in the weak-alias list -
+// a weak alias and a definition of one symbol in one translation unit is a
+// redefinition error.
+void WDT0_IRQHandler(void);
 
 // External interrupts handlers
 __attribute__ ((weak, alias("Dummy_Handler"))) void FPU_IRQHandler(void);
@@ -92,7 +96,6 @@ __attribute__ ((weak, alias("Dummy_Handler"))) void TIMER1_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void TIMER2_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void RTC0_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void RTC1_IRQHandler(void);
-__attribute__ ((weak, alias("Dummy_Handler"))) void WDT0_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void WDT1_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void COMP_LPCOMP_IRQHandler(void);
 __attribute__ ((weak, alias("Dummy_Handler"))) void EGU0_IRQHandler(void);
@@ -351,6 +354,30 @@ void SecureFault_Handler(void) {
          "2:                        ;"
          "mov    R1, LR             ;"  // EXC_RETURN passed through R1.
          "b      SecureFaultHandler ;"  // Stack frame passed through R0.
+    );
+}
+
+// WDT0's TIMEOUT interrupt exists only to answer "where was the app stuck?".
+// Same trampoline as the fault handlers, and for the same reason: WDT0 is
+// secure and the interrupted context is normally the non-secure application,
+// so its stack frame is on the non-secure stack.
+void WDT0_IRQHandler(void) {
+    __ASM(
+         "tst    LR, #0x40              ;"  // EXC_RETURN bit 6 (S): secure background?
+         "bne    1f                     ;"
+         "tst    LR, #4                 ;"  // non-secure background: pick NS stack
+         "ite    EQ                     ;"
+         "mrseq  R0, MSP_NS             ;"
+         "mrsne  R0, PSP_NS             ;"
+         "b      2f                     ;"
+         "1:                            ;"
+         "tst    LR, #4                 ;"  // secure background: pick secure stack
+         "ite    EQ                     ;"
+         "mrseq  R0, MSP                ;"
+         "mrsne  R0, PSP                ;"
+         "2:                            ;"
+         "mov    R1, LR                 ;"  // EXC_RETURN passed through R1.
+         "b      crash_latch_watchdog   ;"  // Stack frame passed through R0.
     );
 }
 

--- a/device/network_core/Source/ipc.h
+++ b/device/network_core/Source/ipc.h
@@ -119,6 +119,8 @@ typedef struct __attribute__((packed)) {
     uint32_t sfsr;          ///< Secure Fault Status Register at fault
     uint32_t pc;            ///< Stacked program counter at fault
     uint32_t lr;            ///< Stacked link register at fault
+    uint32_t sp;            ///< Stack pointer of the interrupted context (its exception frame address)
+    uint32_t psr;           ///< Stacked xPSR; IPSR field names the active exception, 0 for thread mode
 } ipc_crash_report_t;
 
 typedef struct __attribute__((packed)) {

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -725,9 +725,7 @@ def generate_info(status_data, devices=[], show_raw=False):
             # The IPSR decode is the point of carrying psr: it says whether the
             # bot was in an interrupt handler, which a pc in a shared driver
             # function cannot tell you on its own.
-            table.add_row(
-                "  psr", f"0x{d.psr:08x}  (in {decode_ipsr(d.psr)})"
-            )
+            table.add_row("  psr", f"0x{d.psr:08x}  (in {decode_ipsr(d.psr)})")
 
         # Both raw packets together, because the pair is what makes the two
         # channels legible: the status frame arrives every second and its last

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -57,6 +57,7 @@ from swarmit.testbed.protocol import (
     PayloadType,
     StatusType,
     decode_cfsr,
+    decode_ipsr,
     decode_reset_reason,
     decode_sfsr,
     decode_string_field,
@@ -238,6 +239,8 @@ class NodeStatus:
     sfsr: int = 0
     pc: int = 0
     lr: int = 0
+    sp: int = 0
+    psr: int = 0
     raw: str = ""  # hex of the full status packet as received
     last_updated_at: float = 0
     # Generation counter as of the most recent status frame. When it differs
@@ -718,6 +721,13 @@ def generate_info(status_data, devices=[], show_raw=False):
             elf = "app image" if d.from_ns else "bootloader image"
             table.add_row("  pc", f"0x{d.pc:08x}  (resolve against {elf})")
             table.add_row("  lr", f"0x{d.lr:08x}")
+            table.add_row("  sp", f"0x{d.sp:08x}")
+            # The IPSR decode is the point of carrying psr: it says whether the
+            # bot was in an interrupt handler, which a pc in a shared driver
+            # function cannot tell you on its own.
+            table.add_row(
+                "  psr", f"0x{d.psr:08x}  (in {decode_ipsr(d.psr)})"
+            )
 
         # Both raw packets together, because the pair is what makes the two
         # channels legible: the status frame arrives every second and its last
@@ -1141,6 +1151,8 @@ class Controller:
                 sfsr=packet.payload.sfsr,
                 pc=packet.payload.pc,
                 lr=packet.payload.lr,
+                sp=packet.payload.sp,
+                psr=packet.payload.psr,
                 raw=packet.to_bytes().hex(),
                 last_updated_at=now,
                 info_gen=packet.payload.info_gen,

--- a/swarmit/testbed/controller.py
+++ b/swarmit/testbed/controller.py
@@ -331,6 +331,11 @@ def format_reset_cause(device_data) -> str:
         # lockup if the fault handler itself wedged) - it disambiguates the
         # crash path at a glance.
         reset_name = decode_reset_reason(rr)
+        if device_data.fault == FaultType.WatchdogTimeout.value:
+            # No fault was raised here - the application just missed its
+            # deadline. Calling that "crashed" sends an operator hunting for a
+            # fault that does not exist; the pc is the whole answer.
+            return f"hung ({reset_name} pc=0x{device_data.pc:08x})"
         if device_data.fault:
             return (
                 f"crashed ({reset_name} {_fault_name(device_data)} "
@@ -691,16 +696,25 @@ def generate_info(status_data, devices=[], show_raw=False):
             + (" (secure)" if d.fault and not d.from_ns else ""),
         )
         if d.fault:
-            cfsr_bits = decode_cfsr(d.cfsr)
-            sfsr_bits = decode_sfsr(d.sfsr)
-            table.add_row(
-                "  cfsr",
-                f"0x{d.cfsr:08x}" + (f" ({cfsr_bits})" if cfsr_bits else ""),
-            )
-            table.add_row(
-                "  sfsr",
-                f"0x{d.sfsr:08x}" + (f" ({sfsr_bits})" if sfsr_bits else ""),
-            )
+            # Only a real fault sets these. A watchdog timeout raised none, so
+            # both registers read zero - printing them invites the reader to
+            # decode a status that was never populated.
+            if d.fault in (
+                FaultType.HardFault.value,
+                FaultType.SecureFault.value,
+            ):
+                cfsr_bits = decode_cfsr(d.cfsr)
+                sfsr_bits = decode_sfsr(d.sfsr)
+                table.add_row(
+                    "  cfsr",
+                    f"0x{d.cfsr:08x}"
+                    + (f" ({cfsr_bits})" if cfsr_bits else ""),
+                )
+                table.add_row(
+                    "  sfsr",
+                    f"0x{d.sfsr:08x}"
+                    + (f" ({sfsr_bits})" if sfsr_bits else ""),
+                )
             elf = "app image" if d.from_ns else "bootloader image"
             table.add_row("  pc", f"0x{d.pc:08x}  (resolve against {elf})")
             table.add_row("  lr", f"0x{d.lr:08x}")

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -94,6 +94,10 @@ class FaultType(Enum):
     NoFault = 0
     HardFault = 1
     SecureFault = 2
+    # No fault was raised: WDT0 timed out because the application stopped
+    # reloading it. pc/lr name where it was stuck; cfsr/sfsr are structurally
+    # zero, so the inspect view skips them for this one.
+    WatchdogTimeout = 3
 
 
 # nRF5340 application core RESETREAS flags (bit position -> short label).

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -217,15 +217,11 @@ def decode_ipsr(psr: int) -> str:
     return f"exception {number}"
 
 
-# Size of the status payload sent by firmware without crash-report support.
-STATUS_LEGACY_SIZE = 12
+# The fixed head of the status payload: device, status, battery, position.
+STATUS_BASE_SIZE = 12
 # Size of the crash report appended to status payloads (mirrors
 # ipc_crash_report_t in the swarmit firmware).
 CRASH_REPORT_SIZE = 30
-# The first crash report, before sp/psr were added. Firmware in the field still
-# sends this, and the two extra words land *inside* the report rather than at
-# the end of the frame, so upgrading it is a splice and not a zero-filled tail.
-CRASH_REPORT_V1_SIZE = 22
 # Size of the generation counter appended after the crash report.
 INFO_GEN_SIZE = 1
 
@@ -387,27 +383,11 @@ class PayloadStatus(Payload):
     # steady state costs no device-info traffic at all.
     info_gen: int = 0
 
-    def from_bytes(self, bytes_):
-        # Each block was appended to this frame in a different release, so a
-        # short payload means "that firmware predates this field", not a
-        # corrupt frame. Upgrade oldest-first so a mixed fleet keeps reporting
-        # status through a rollout.
-        raw = bytes(bytes_)
-        if len(raw) == STATUS_LEGACY_SIZE:
-            raw += bytes(CRASH_REPORT_V1_SIZE)
-        if len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE:
-            raw += bytes(INFO_GEN_SIZE)
-        if len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE + INFO_GEN_SIZE:
-            # sp/psr were appended to the crash report, which puts them *ahead*
-            # of the trailing info_gen byte rather than at the end of the frame.
-            # Zero-filling the tail would land them on info_gen and shift it out
-            # of position, so this one is a splice.
-            raw = (
-                raw[:-INFO_GEN_SIZE]
-                + bytes(CRASH_REPORT_SIZE - CRASH_REPORT_V1_SIZE)
-                + raw[-INFO_GEN_SIZE:]
-            )
-        return super().from_bytes(raw)
+    # There is deliberately no upgrade path for a shorter frame. Firmware and
+    # host ship together, so a payload of any other shape comes from a bot too
+    # old to talk to: the adapter drops the frame and the bot never appears,
+    # which is the wanted outcome. Reflashing is the fix, and `swarm flash`
+    # already refuses those bots by bootloader version.
 
 
 @dataclass

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -729,14 +729,12 @@ class PayloadDeviceInfo(Payload):
     lh2_homography_count: int = 0
     lh2_flags: int = 0
 
-    def from_bytes(self, bytes_):
-        # A device speaking a newer schema appends fields; parse the prefix we
-        # know and ignore the rest rather than refusing the whole reply. A
-        # short payload is zero-filled for the same reason the status frame
-        # is: it means "older firmware", not "corrupt".
-        if len(bytes_) < self.size:
-            bytes_ = bytes(bytes_) + bytes(self.size - len(bytes_))
-        return super().from_bytes(bytes_[: self.size])
+    # No from_bytes override, for the same reason PayloadStatus has none: a
+    # reply that is not this shape comes from a bot too old to talk to, and
+    # zero-filling it invented a record rather than reporting nothing. It now
+    # raises, the adapter drops the frame, and the cached info simply does not
+    # update. Trailing bytes from a newer schema need no handling either - the
+    # base parser consumes the fields it knows and ignores the rest.
 
 
 @dataclass

--- a/swarmit/testbed/protocol.py
+++ b/swarmit/testbed/protocol.py
@@ -184,11 +184,48 @@ def decode_sfsr(sfsr: int) -> str:
     return _decode_flags(sfsr, SFSR_FLAGS)
 
 
+# ARMv8-M exception numbers, as they appear in xPSR's IPSR field. Numbers at or
+# above 16 are external interrupts, IRQ = number - 16.
+IPSR_EXCEPTIONS = {
+    0: "thread",
+    2: "NMI",
+    3: "HardFault",
+    4: "MemManage",
+    5: "BusFault",
+    6: "UsageFault",
+    7: "SecureFault",
+    11: "SVCall",
+    12: "DebugMonitor",
+    14: "PendSV",
+    15: "SysTick",
+}
+
+
+def decode_ipsr(psr: int) -> str:
+    """Name the exception the interrupted context was running in.
+
+    IPSR is the low 9 bits of xPSR. `thread` means ordinary application code;
+    anything else means the hang or fault happened inside a handler, which is
+    the one thing this field tells you that the pc alone does not - a pc in a
+    driver function reads the same either way.
+    """
+    number = psr & 0x1FF
+    if number in IPSR_EXCEPTIONS:
+        return IPSR_EXCEPTIONS[number]
+    if number >= 16:
+        return f"IRQ {number - 16}"
+    return f"exception {number}"
+
+
 # Size of the status payload sent by firmware without crash-report support.
 STATUS_LEGACY_SIZE = 12
 # Size of the crash report appended to status payloads (mirrors
 # ipc_crash_report_t in the swarmit firmware).
-CRASH_REPORT_SIZE = 22
+CRASH_REPORT_SIZE = 30
+# The first crash report, before sp/psr were added. Firmware in the field still
+# sends this, and the two extra words land *inside* the report rather than at
+# the end of the frame, so upgrading it is a splice and not a zero-filled tail.
+CRASH_REPORT_V1_SIZE = 22
 # Size of the generation counter appended after the crash report.
 INFO_GEN_SIZE = 1
 
@@ -325,6 +362,8 @@ class PayloadStatus(Payload):
             PayloadFieldMetadata(name="sfsr", disp="sfsr", length=4),
             PayloadFieldMetadata(name="pc", disp="pc", length=4),
             PayloadFieldMetadata(name="lr", disp="lr", length=4),
+            PayloadFieldMetadata(name="sp", disp="sp", length=4),
+            PayloadFieldMetadata(name="psr", disp="psr", length=4),
             PayloadFieldMetadata(name="info_gen", disp="gen"),
         ]
     )
@@ -341,6 +380,8 @@ class PayloadStatus(Payload):
     sfsr: int = 0
     pc: int = 0
     lr: int = 0
+    sp: int = 0
+    psr: int = 0
     # Changes whenever anything in the device-info block changes. The
     # controller refetches on any difference from what it cached, so the
     # steady state costs no device-info traffic at all.
@@ -349,13 +390,24 @@ class PayloadStatus(Payload):
     def from_bytes(self, bytes_):
         # Each block was appended to this frame in a different release, so a
         # short payload means "that firmware predates this field", not a
-        # corrupt frame. Zero-fill the missing tail so a mixed fleet keeps
-        # reporting status through a rollout.
-        if len(bytes_) == STATUS_LEGACY_SIZE:
-            bytes_ = bytes(bytes_) + bytes(CRASH_REPORT_SIZE)
-        if len(bytes_) == STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE:
-            bytes_ = bytes(bytes_) + bytes(INFO_GEN_SIZE)
-        return super().from_bytes(bytes_)
+        # corrupt frame. Upgrade oldest-first so a mixed fleet keeps reporting
+        # status through a rollout.
+        raw = bytes(bytes_)
+        if len(raw) == STATUS_LEGACY_SIZE:
+            raw += bytes(CRASH_REPORT_V1_SIZE)
+        if len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE:
+            raw += bytes(INFO_GEN_SIZE)
+        if len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE + INFO_GEN_SIZE:
+            # sp/psr were appended to the crash report, which puts them *ahead*
+            # of the trailing info_gen byte rather than at the end of the frame.
+            # Zero-filling the tail would land them on info_gen and shift it out
+            # of position, so this one is a splice.
+            raw = (
+                raw[:-INFO_GEN_SIZE]
+                + bytes(CRASH_REPORT_SIZE - CRASH_REPORT_V1_SIZE)
+                + raw[-INFO_GEN_SIZE:]
+            )
+        return super().from_bytes(raw)
 
 
 @dataclass

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -1098,7 +1098,9 @@ def test_a_hang_is_not_reported_as_a_crash():
         fault=FaultType.HardFault.value,
         pc=0x0001_3A4E,
     )
-    assert format_reset_cause(crashed).startswith("crashed (watchdog0 HardFault")
+    assert format_reset_cause(crashed).startswith(
+        "crashed (watchdog0 HardFault"
+    )
 
     # Firmware predating the capture, and the case where the handler could not
     # run: WDT0 fired with nothing latched. Still a crash, still no address.

--- a/swarmit/tests/test_controller.py
+++ b/swarmit/tests/test_controller.py
@@ -22,7 +22,11 @@ from swarmit.testbed.controller import (
 )
 from swarmit.testbed.logger import setup_logging
 from swarmit.testbed.ota import BlockOTASettings
-from swarmit.testbed.protocol import OTA_PROTOCOL_VERSION_LEGACY, StatusType
+from swarmit.testbed.protocol import (
+    OTA_PROTOCOL_VERSION_LEGACY,
+    FaultType,
+    StatusType,
+)
 from swarmit.tests.utils import (
     ChunkLossStrategy,
     MarilibMQTTAdapterMock,
@@ -1073,6 +1077,33 @@ def test_reset_reason_row_drops_a_redundant_decode():
     assert decode_reset_reason(0x1C) == "ctrl-ap+soft-reset+lockup"
     assert format_reset_cause(multi) == "lockup"
     assert decode_reset_reason(0x1C) != format_reset_cause(multi)
+
+
+def test_a_hang_is_not_reported_as_a_crash():
+    """A watchdog timeout raised no fault, so "crashed" would misdirect.
+
+    The operator-facing distinction is the point of the whole change: "hung"
+    plus an address sends someone to the function that overran, where
+    "crashed" sends them looking for a fault status that was never populated.
+    """
+    hung = NodeStatus(
+        reset_reason=0x2,  # watchdog0
+        fault=FaultType.WatchdogTimeout.value,
+        pc=0x0001_3A4E,
+    )
+    assert format_reset_cause(hung) == "hung (watchdog0 pc=0x00013a4e)"
+
+    crashed = NodeStatus(
+        reset_reason=0x2,
+        fault=FaultType.HardFault.value,
+        pc=0x0001_3A4E,
+    )
+    assert format_reset_cause(crashed).startswith("crashed (watchdog0 HardFault")
+
+    # Firmware predating the capture, and the case where the handler could not
+    # run: WDT0 fired with nothing latched. Still a crash, still no address.
+    silent = NodeStatus(reset_reason=0x2)
+    assert format_reset_cause(silent) == "crashed (watchdog0)"
 
 
 def test_info_panel_does_not_repeat_the_boot_reason():

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -11,6 +11,7 @@ from swarmit.testbed.protocol import (
     PayloadRequestMessage,
     PayloadStatus,
     PayloadType,
+    FaultType,
     boot_reason,
     decode_cfsr,
     decode_reset_reason,
@@ -244,6 +245,10 @@ def test_image_digest_length_matches_firmware():
         (1 << 4, 0, "Unspecified"),
         # A latched fault wins over everything.
         (1 << 3, 1, "HardwareWatchdogReset"),
+        # A watchdog timeout latches fault=3 without any fault being raised.
+        # It is a genuine watchdog reset, so the Matter value is unchanged -
+        # the distinction lives in format_reset_cause, not here.
+        (1 << 1, 3, "HardwareWatchdogReset"),
     ],
 )
 def test_boot_reason_mapping(reset_reason, fault, expected):
@@ -254,3 +259,31 @@ def test_boot_reason_is_derived_not_transmitted():
     # The device does not send it: everything the mapping needs already rides
     # the status frame, so a fix is a host change rather than a reflash.
     assert not hasattr(PayloadDeviceInfo(), "boot_reason")
+
+
+def test_watchdog_timeout_rides_the_existing_crash_report():
+    """A hang costs no wire bytes: it reuses fault, pc and lr.
+
+    The whole point of spending a fault enumerator rather than new fields is
+    that the frame length does not move, so a fleet mid-rollout keeps parsing.
+    """
+    payload = PayloadStatus(
+        device=1,
+        status=2,
+        reset_reason=0x2,  # watchdog0
+        fault=FaultType.WatchdogTimeout.value,
+        from_ns=1,
+        pc=0x0001_3A4E,
+        lr=0x0001_39C0,
+    )
+    raw = payload.to_bytes()
+    assert len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE + INFO_GEN_SIZE
+
+    parsed = PayloadStatus().from_bytes(bytes(raw))
+    assert parsed.fault == 3
+    assert parsed.from_ns == 1
+    assert parsed.pc == 0x0001_3A4E
+    assert parsed.lr == 0x0001_39C0
+    # No fault was raised, so the fault-status registers stay empty.
+    assert parsed.cfsr == 0
+    assert parsed.sfsr == 0

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -6,12 +6,12 @@ from swarmit.testbed.protocol import (
     INFO_GEN_SIZE,
     INFO_STRING_LEN,
     STATUS_BASE_SIZE,
+    FaultType,
     PayloadDeviceInfo,
     PayloadOTAStart,
     PayloadRequestMessage,
     PayloadStatus,
     PayloadType,
-    FaultType,
     boot_reason,
     decode_cfsr,
     decode_ipsr,
@@ -57,7 +57,6 @@ def test_payload_status_round_trip():
     assert parsed.lr == 0x0001_2340
 
 
-
 def test_payload_status_truncated_frame_raises():
     with pytest.raises(ValueError):
         PayloadStatus().from_bytes(bytes(5))
@@ -92,7 +91,6 @@ def test_decode_sfsr():
     # NS write into a secure region -> attribution unit violation
     assert decode_sfsr(1 << 3) == "AUVIOL"
     assert decode_sfsr(1 << 0) == "INVEP"
-
 
 
 def test_device_info_matches_firmware_wire_size():
@@ -261,8 +259,6 @@ def test_watchdog_timeout_rides_the_existing_crash_report():
     # No fault was raised, so the fault-status registers stay empty.
     assert parsed.cfsr == 0
     assert parsed.sfsr == 0
-
-
 
 
 @pytest.mark.parametrize(

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -2,11 +2,10 @@ import pytest
 
 from swarmit.testbed.protocol import (
     CRASH_REPORT_SIZE,
-    CRASH_REPORT_V1_SIZE,
     IMAGE_DIGEST_LEN,
     INFO_GEN_SIZE,
     INFO_STRING_LEN,
-    STATUS_LEGACY_SIZE,
+    STATUS_BASE_SIZE,
     PayloadDeviceInfo,
     PayloadOTAStart,
     PayloadRequestMessage,
@@ -40,7 +39,7 @@ def test_payload_status_round_trip():
         info_gen=7,
     )
     raw = payload.to_bytes()
-    assert len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE + INFO_GEN_SIZE
+    assert len(raw) == STATUS_BASE_SIZE + CRASH_REPORT_SIZE + INFO_GEN_SIZE
 
     parsed = PayloadStatus().from_bytes(bytes(raw))
     assert parsed.info_gen == 7
@@ -57,24 +56,6 @@ def test_payload_status_round_trip():
     assert parsed.pc == 0x0001_2345
     assert parsed.lr == 0x0001_2340
 
-
-def test_payload_status_legacy_frame():
-    # Status payload from firmware without crash-report support: 12 bytes,
-    # crash report fields parse as zero.
-    legacy = PayloadStatus(
-        device=1, status=1, battery=2900, pos_x=42, pos_y=43
-    ).to_bytes()[:STATUS_LEGACY_SIZE]
-
-    parsed = PayloadStatus().from_bytes(bytes(legacy))
-    assert parsed.device == 1
-    assert parsed.status == 1
-    assert parsed.battery == 2900
-    assert parsed.pos_x == 42
-    assert parsed.pos_y == 43
-    assert parsed.reset_reason == 0
-    assert parsed.fault == 0
-    assert parsed.from_ns == 0
-    assert parsed.pc == 0
 
 
 def test_payload_status_truncated_frame_raises():
@@ -112,18 +93,6 @@ def test_decode_sfsr():
     assert decode_sfsr(1 << 3) == "AUVIOL"
     assert decode_sfsr(1 << 0) == "INVEP"
 
-
-def test_payload_status_pre_generation_frame():
-    # Firmware with a crash report but no generation counter: the frame is one
-    # byte short and must still parse, reporting generation 0. That firmware
-    # predates sp/psr, so its report is the v1 size - a frame carrying the
-    # current 30-byte report and no generation counter never shipped.
-    frame = PayloadStatus(device=1, status=1, battery=2900).to_bytes()[
-        : STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE
-    ]
-    parsed = PayloadStatus().from_bytes(bytes(frame))
-    assert parsed.battery == 2900
-    assert parsed.info_gen == 0
 
 
 def test_device_info_matches_firmware_wire_size():
@@ -266,10 +235,11 @@ def test_boot_reason_is_derived_not_transmitted():
 
 
 def test_watchdog_timeout_rides_the_existing_crash_report():
-    """A hang costs no wire bytes: it reuses fault, pc and lr.
+    """A hang reuses fault, pc and lr rather than adding fields of its own.
 
-    The whole point of spending a fault enumerator rather than new fields is
-    that the frame length does not move, so a fleet mid-rollout keeps parsing.
+    Spending a fault enumerator keeps the two cases - crashed and hung - in
+    one shape, so everything that reads a crash report reads both without
+    branching on which kind it is.
     """
     payload = PayloadStatus(
         device=1,
@@ -281,7 +251,7 @@ def test_watchdog_timeout_rides_the_existing_crash_report():
         lr=0x0001_39C0,
     )
     raw = payload.to_bytes()
-    assert len(raw) == STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE + INFO_GEN_SIZE
+    assert len(raw) == STATUS_BASE_SIZE + CRASH_REPORT_SIZE + INFO_GEN_SIZE
 
     parsed = PayloadStatus().from_bytes(bytes(raw))
     assert parsed.fault == 3
@@ -293,58 +263,6 @@ def test_watchdog_timeout_rides_the_existing_crash_report():
     assert parsed.sfsr == 0
 
 
-def test_payload_status_v1_crash_report_splices_sp_psr():
-    """Firmware predating sp/psr sends a 35-byte frame; info_gen must survive.
-
-    The two new words were appended to the crash report, which puts them ahead
-    of the trailing generation counter rather than at the end of the frame. A
-    zero-filled tail would land them on info_gen and shift it out of position,
-    so this is the one upgrade step that has to splice.
-    """
-    v1 = PayloadStatus(
-        device=1,
-        status=2,
-        battery=2800,
-        reset_reason=0x2,
-        fault=FaultType.WatchdogTimeout.value,
-        from_ns=1,
-        pc=0x0001_3A4E,
-        lr=0x0001_39C0,
-        info_gen=7,
-    )
-    # Build the old wire shape by dropping the two words this release added.
-    full = bytes(v1.to_bytes())
-    old = (
-        full[: STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE]
-        + full[-INFO_GEN_SIZE:]
-    )
-    assert len(old) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE + INFO_GEN_SIZE
-
-    parsed = PayloadStatus().from_bytes(old)
-    # Everything before the splice point is untouched...
-    assert parsed.battery == 2800
-    assert parsed.fault == 3
-    assert parsed.pc == 0x0001_3A4E
-    assert parsed.lr == 0x0001_39C0
-    # ...the new fields read as absent...
-    assert parsed.sp == 0
-    assert parsed.psr == 0
-    # ...and info_gen is still the generation counter, not a byte of sp.
-    assert parsed.info_gen == 7
-
-
-def test_payload_status_legacy_frames_still_reach_the_current_shape():
-    """The 12- and 34-byte frames climb the whole ladder, not just one rung."""
-    for size in (
-        STATUS_LEGACY_SIZE,
-        STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE,
-    ):
-        parsed = PayloadStatus().from_bytes(bytes(size))
-        assert parsed.fault == 0
-        assert parsed.pc == 0
-        assert parsed.sp == 0
-        assert parsed.psr == 0
-        assert parsed.info_gen == 0
 
 
 @pytest.mark.parametrize(

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -130,14 +130,21 @@ def test_payload_device_info_round_trip():
     assert parsed.lh2_flags == 0b11
 
 
-def test_payload_device_info_short_payload_does_not_raise():
-    # A bot running older firmware, or a truncated frame, parses as zeros
-    # rather than taking down the RX thread.
-    parsed = PayloadDeviceInfo().from_bytes(b"\x01\x05")
+def test_payload_device_info_short_payload_raises():
+    # A reply that is not the full record comes from a bot too old to talk to.
+    # Zero-filling it invented a device record; raising lets the adapter drop
+    # the frame and leaves the cached info untouched.
+    with pytest.raises(ValueError):
+        PayloadDeviceInfo().from_bytes(b"\x01\x05")
+
+
+def test_payload_device_info_tolerates_trailing_bytes():
+    # A device on a newer schema appends fields. The known prefix still parses
+    # and the rest is ignored, so the host does not need its own truncation.
+    full = bytes(PayloadDeviceInfo(info_version=1, info_gen=42).to_bytes())
+    parsed = PayloadDeviceInfo().from_bytes(full + b"\xde\xad\xbe\xef")
     assert parsed.info_version == 1
-    assert parsed.info_gen == 5
-    assert parsed.image_size == 0
-    assert decode_string_field(parsed.image_name) == ""
+    assert parsed.info_gen == 42
 
 
 def test_string_fields_are_nul_padded_and_truncated():

--- a/swarmit/tests/test_protocol.py
+++ b/swarmit/tests/test_protocol.py
@@ -2,6 +2,7 @@ import pytest
 
 from swarmit.testbed.protocol import (
     CRASH_REPORT_SIZE,
+    CRASH_REPORT_V1_SIZE,
     IMAGE_DIGEST_LEN,
     INFO_GEN_SIZE,
     INFO_STRING_LEN,
@@ -14,6 +15,7 @@ from swarmit.testbed.protocol import (
     FaultType,
     boot_reason,
     decode_cfsr,
+    decode_ipsr,
     decode_reset_reason,
     decode_sfsr,
     decode_string_field,
@@ -113,9 +115,11 @@ def test_decode_sfsr():
 
 def test_payload_status_pre_generation_frame():
     # Firmware with a crash report but no generation counter: the frame is one
-    # byte short and must still parse, reporting generation 0.
+    # byte short and must still parse, reporting generation 0. That firmware
+    # predates sp/psr, so its report is the v1 size - a frame carrying the
+    # current 30-byte report and no generation counter never shipped.
     frame = PayloadStatus(device=1, status=1, battery=2900).to_bytes()[
-        : STATUS_LEGACY_SIZE + CRASH_REPORT_SIZE
+        : STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE
     ]
     parsed = PayloadStatus().from_bytes(bytes(frame))
     assert parsed.battery == 2900
@@ -287,3 +291,71 @@ def test_watchdog_timeout_rides_the_existing_crash_report():
     # No fault was raised, so the fault-status registers stay empty.
     assert parsed.cfsr == 0
     assert parsed.sfsr == 0
+
+
+def test_payload_status_v1_crash_report_splices_sp_psr():
+    """Firmware predating sp/psr sends a 35-byte frame; info_gen must survive.
+
+    The two new words were appended to the crash report, which puts them ahead
+    of the trailing generation counter rather than at the end of the frame. A
+    zero-filled tail would land them on info_gen and shift it out of position,
+    so this is the one upgrade step that has to splice.
+    """
+    v1 = PayloadStatus(
+        device=1,
+        status=2,
+        battery=2800,
+        reset_reason=0x2,
+        fault=FaultType.WatchdogTimeout.value,
+        from_ns=1,
+        pc=0x0001_3A4E,
+        lr=0x0001_39C0,
+        info_gen=7,
+    )
+    # Build the old wire shape by dropping the two words this release added.
+    full = bytes(v1.to_bytes())
+    old = (
+        full[: STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE]
+        + full[-INFO_GEN_SIZE:]
+    )
+    assert len(old) == STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE + INFO_GEN_SIZE
+
+    parsed = PayloadStatus().from_bytes(old)
+    # Everything before the splice point is untouched...
+    assert parsed.battery == 2800
+    assert parsed.fault == 3
+    assert parsed.pc == 0x0001_3A4E
+    assert parsed.lr == 0x0001_39C0
+    # ...the new fields read as absent...
+    assert parsed.sp == 0
+    assert parsed.psr == 0
+    # ...and info_gen is still the generation counter, not a byte of sp.
+    assert parsed.info_gen == 7
+
+
+def test_payload_status_legacy_frames_still_reach_the_current_shape():
+    """The 12- and 34-byte frames climb the whole ladder, not just one rung."""
+    for size in (
+        STATUS_LEGACY_SIZE,
+        STATUS_LEGACY_SIZE + CRASH_REPORT_V1_SIZE,
+    ):
+        parsed = PayloadStatus().from_bytes(bytes(size))
+        assert parsed.fault == 0
+        assert parsed.pc == 0
+        assert parsed.sp == 0
+        assert parsed.psr == 0
+        assert parsed.info_gen == 0
+
+
+@pytest.mark.parametrize(
+    "psr,expected",
+    [
+        (0x0100_0000, "thread"),  # T bit set, IPSR 0: ordinary app code
+        (0x0100_0003, "HardFault"),
+        (0x0100_000F, "SysTick"),
+        (0x0100_001A, "IRQ 10"),  # 26 - 16
+        (0x0000_0009, "exception 9"),  # reserved, reported honestly
+    ],
+)
+def test_decode_ipsr(psr, expected):
+    assert decode_ipsr(psr) == expected


### PR DESCRIPTION
The crash report added in #154 covers faults: a HardFault or SecureFault latches
`cfsr`/`sfsr`/`pc`/`lr` into `.non_init`, the handler spins until WDT0 resets the
SoC, and the next boot publishes it. A **hang** loses all of that. When the app
simply stops calling `swarmit_keep_alive()` - stuck in a loop, blocking on a
peripheral, or just doing more than 1 s of work between reloads - WDT0 fires with
no fault raised, nothing is latched, and the operator sees `crashed (watchdog0)`
with no indication of where. That is precisely when you want an address: it names
the function that overran.

The nRF5340 gives you the window for free. Per the PS section 7.41.3, enabling
the WDT0 TIMEOUT interrupt postpones the reset by two 32.768 kHz cycles (~61 us,
about 7800 cycles at 128 MHz). The reset is not cancellable, so this adds a
diagnostic without weakening the deadman. `setup_watchdog0()` simply never wrote
`INTENSET`, so `WDT0_IRQHandler` was still weak-aliased to `Dummy_Handler`.

The handler is the same trampoline shape as the two fault handlers, for the same
reason: WDT0 is secure and the interrupted context is normally the non-secure
app, so the frame sits on the non-secure stack.

Two details worth a reviewer's eye:

- **The magic guard in `crash_latch_watchdog()` is load-bearing, not defensive.**
  A fault handler that already latched is spinning *waiting for this exact
  timeout*, so without the guard the watchdog snapshot would overwrite the real
  fault with the address of the spin loop. `reset_reason` reads `watchdog0` in
  both cases, which is what makes the two indistinguishable without it.
- **`startup.c`'s weak alias for `WDT0_IRQHandler` had to be removed**, not just
  shadowed - a weak alias plus a strong definition in one translation unit is a
  redefinition error. That is why the two existing fault handlers are declared
  plainly and are absent from the alias list.

The crash report also gains `sp` and `psr`, because a pc alone cannot tell an
ISR hang from a thread-mode one - a pc inside a shared driver function reads the
same either way. `psr`'s IPSR field names the active exception; note it carries
the exception number, so IRQ n appears as n+16 and reporting it raw would
mislabel a TIMER0 hang as SysTick.

## Wire format

The crash report grows 22 to 30 bytes and the status frame 35 to 43. There is
**no compatibility path**, by choice: firmware and host ship together, a release
is imminent, and bots too old to speak this are meant to be retired rather than
carried. A frame of any other shape now fails to parse and the adapter drops it,
so such a bot never appears in `status` - and `swarm flash` already refuses it by
bootloader version, which is the mechanism that identifies it. Reflash or retire.

The same reasoning removes the device-info reply's zero-fill: a short reply now
raises and the cached record is left untouched, instead of inventing one full
of zeros that reads as a real answer.

The second commit is a separable correctness fix, reviewable on its own:
`ipc_shared_data` lives in `.shared_data`, which is `load="No"` and outside the
startup zeroing loops, so when no latch is valid the fault fields kept the
*previous* boot's snapshot - or uninitialized RAM on a cold boot, where a random
non-zero `fault` byte reported a crash on a device that was merely switched on.

## Validation

Host suite: 190 passed. Both cores rebuilt and their layouts confirmed identical
by `gdb ptype /o` (30 bytes, `crash_report` at `0x674`, `sp` at 22, `psr` at 26
on each side) - the check that matters whenever the shared IPC struct moves.

Bench run on a DotBot v3 (2.98 V), four cases, each address predicted from the
ELF before the run and matched exactly:

- **Hang in thread mode.** Reported `hung (watchdog0 pc=0x000107c0)`,
  `fault WatchdogTimeout (non-secure)`; `addr2line` resolved it to the hanging
  function.
- **Hang inside an ISR.** `psr 0x6100001f` decoded to `in IRQ 15`, matching
  `TIMER0_IRQn` - which the pc alone could not have told you.
- **Guard.** A NULL store still latched `SecureFault` with
  `sfsr 0x48 (AUVIOL+SFARVALID)` and printed `crashed`, not `hung`.
- **Stale report.** The boot immediately after that crash came back
  `fault NoFault` with no pc/lr, where the old code would still have shown the
  previous boot's fault and address.

One caveat worth knowing when reading a report: an SPU AUVIOL on a buffered
write is imprecise, so a *fault* pc can land a few instructions past the
offending store. The *watchdog* pc does not have this problem - the CPU
genuinely is executing that instruction when the interrupt arrives - so this
capture is the more precise of the two. Relatedly, `lr` is unreliable for an ISR
hang: a leaf that never spills LR leaves whatever the register last held, so
only pc, sp and psr are trustworthy there.
